### PR TITLE
Update README to reflect the new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Web Model Context API 🧪
+# WebMCP 🧪
 
-This is a repository for the [Web Machine Learning Community Group](https://www.w3.org/groups/cg/webmachinelearning/) ([join](https://webmachinelearning.github.io/community/#join)) to continue discussion on the [Web Model Context API proposal](https://github.com/webmachinelearning/proposals/issues/12).
+This is a repository for the [Web Machine Learning Community Group](https://www.w3.org/groups/cg/webmachinelearning/) ([join](https://webmachinelearning.github.io/community/#join)) to continue discussion on the [proposal](https://github.com/webmachinelearning/proposals/issues/12).
 
 ## Scope of Work
 


### PR DESCRIPTION
A trivial change to reflect the recent rename to README.

Also serves as a reminder we can make this landing page more useful when we have the pieces in place.