### PR TITLE
Add authors and date to explainer and proposal

### DIFF
--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -2,6 +2,14 @@
 
 _Enabling web apps to provide JavaScript-based tools that can be accessed by AI agents and assistive technologies to create collaborative, human-in-the-loop workflows._
 
+> August 13, 2025
+>
+> Brandon Walderman <code>&lt;brwalder@microsoft.com&gt;</code><br>
+> Andrew Nolan <code>&lt;annolan@microsoft.com&gt;</code><br>
+> David Bokan <code>&lt;bokan@google.com&gt;</code><br>
+> Khushal Sagar <code>&lt;khushalsagar@google.com&gt;</code><br>
+> Hannah Van Opstal <code>&lt;hvanopstal@google.com&gt;</code>
+
 ## TL;DR
 
 We propose a new JavaScript interface that allows web developers to expose their web application functionality as "tools" - JavaScript functions with natural language descriptions and structured schemas that can be invoked by AI agents, browser assistants, and assistive technologies. Web pages that use WebMCP can be thought of as [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) servers that implement tools in client-side script instead of on the backend. WebMCP enables collaborative workflows where users and agents work together within the same web interface, leveraging existing application logic while maintaining shared context and user control.

--- a/docs/proposal.md
+++ b/docs/proposal.md
@@ -1,5 +1,13 @@
 # WebMCP API Proposal
 
+> August 13, 2025
+>
+> Brandon Walderman <code>&lt;brwalder@microsoft.com&gt;</code><br>
+> Andrew Nolan <code>&lt;annolan@microsoft.com&gt;</code><br>
+> David Bokan <code>&lt;bokan@google.com&gt;</code><br>
+> Khushal Sagar <code>&lt;khushalsagar@google.com&gt;</code><br>
+> Hannah Van Opstal <code>&lt;hvanopstal@google.com&gt;</code>
+
 ## Definitions
 
 - **Model context provider**: A single top-level browsing context navigated to a page that uses the WebMCP API to provide context (i.e. tools) to agents.


### PR DESCRIPTION
Adding the publish date of the current explainer and crediting the authors of the original Microsoft and Google docs this was derived from.