### PR TITLE
Initialize a Navigator's `modelContext` member

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -122,6 +122,13 @@ partial interface Navigator {
 };
 </xmp>
 
+Each {{Navigator}} object has an associated <dfn for=Navigator>modelContext</dfn>, which is a
+{{ModelContext}} instance created alongside the {{Navigator}}.
+
+<div algorithm>
+The <dfn attribute for=Navigator>modelContext</dfn> getter steps are to return [=this=]'s [=Navigator/modelContext=].
+</div>
+
 <h3 id="model-context-container">ModelContext Interface</h3>
 
 The {{ModelContext}} interface provides methods for web applications to register and manage tools that can be invoked by [=agents=].


### PR DESCRIPTION
This is a small follow-up to https://github.com/webmachinelearning/webmcp/pull/75#discussion_r2769441050, that properly initializes a Navigator's `modelContext` member and describes how its getter behaves.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/pull/98.html" title="Last updated on Feb 19, 2026, 4:19 PM UTC (41dd829)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/98/971aa24...41dd829.html" title="Last updated on Feb 19, 2026, 4:19 PM UTC (41dd829)">Diff</a>