### PR TITLE
Set default value for ToolAnnotations readOnlyHint

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -263,8 +263,8 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>)</dfn> method step
      class=allow-2119>should</span> reconcile this difference.</p>
    </div>
 
-1. Let |read-only hint| be true if |tool|'s {{ModelContextTool/annotations}} [=map/exists=], and if
-   its {{ToolAnnotations/readOnlyHint}} [=map/exists=] and is true. Otherwise, let it be false.
+1. Let |read-only hint| be true if |tool|'s {{ModelContextTool/annotations}} [=map/exists=] and
+   its {{ToolAnnotations/readOnlyHint}} is true. Otherwise, let it be false.
 
 1. Let |tool definition| be a new [=tool definition=], with the following [=struct/items=]:
 


### PR DESCRIPTION
This PR sets a default value of false for ToolAnnotations readOnlyHint since MCP already [defined](https://modelcontextprotocol.io/legacy/concepts/tools#available-tool-annotations) a default value of `false` for `readOnlyHint`.

This PR also uses `dfn-type=dict-member dfn-for=ToolAnnotations` to get this nice automatic formatting:
<img width="865" height="238" alt="image" src="https://github.com/user-attachments/assets/8f7562be-a833-45ed-9a82-231d89aae2e4" />

