### PR TITLE
Add ToolActivatedEvent and ToolCancelEvent interfaces

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -176,9 +176,12 @@ The {{ModelContext}} interface provides methods for web applications to register
 
 <xmp class="idl">
 [Exposed=Window, SecureContext]
-interface ModelContext {
+interface ModelContext : EventTarget {
   undefined registerTool(ModelContextTool tool);
   undefined unregisterTool(DOMString name);
+
+  attribute EventHandler ontoolactivated;
+  attribute EventHandler ontoolcancel;
 };
 </xmp>
 
@@ -196,6 +199,13 @@ is a [=model context=] [=struct=] created alongside the {{ModelContext}}.
   <dd>
     <p>Removes the tool with the specified name from the registered set.
   </dd>
+</dl>
+
+<dl dfn-type=attribute dfn-for=ModelContext>
+    : <dfn>ontoolactivated</dfn>
+    :: An [=event handler IDL attribute=] for the {{ModelContext/toolactivated}} event type.
+    : <dfn>ontoolcancel</dfn>
+    :: An [=event handler IDL attribute=] for the {{ModelContext/toolcancel}} event type.
 </dl>
 
 
@@ -352,6 +362,56 @@ The <dfn method for=ModelContextClient>requestUserInteraction(<var ignore>callba
 1. TODO: fill this out.
 
 </div>
+
+<h4 id="tool-activated-event">ToolActivatedEvent Interface</h4>
+
+The {{ToolActivatedEvent}} interface represents a <dfn event for=ModelContext>toolactivated</dfn> event that is dispatched at {{Navigator/modelContext}} when a tool is invoked by an [=agent=].
+
+<xmp class="idl">
+[Exposed=Window, SecureContext]
+interface ToolActivatedEvent : Event {
+  constructor(DOMString type, optional ToolActivatedEventInit eventInitDict = {});
+  readonly attribute DOMString toolName;
+  readonly attribute Element? element;
+};
+
+dictionary ToolActivatedEventInit : EventInit {
+  DOMString toolName = "";
+  Element? element = null;
+};
+</xmp>
+
+<dl class="domintro" dfn-type=attribute dfn-for=ToolActivatedEvent>
+  : <dfn>toolName</dfn>
+  :: Returns the name of the tool that was activated.
+  : <dfn>element</dfn>
+  :: Returns the form element associated with the tool, if any.
+</dl>
+
+<h4 id="tool-cancel-event">ToolCancelEvent Interface</h4>
+
+The {{ToolCancelEvent}} interface represents a <dfn event for=ModelContext>toolcancel</dfn> event that is dispatched at {{Navigator/modelContext}} when a tool's invocation is canceled by an [=agent=].
+
+<xmp class="idl">
+[Exposed=Window, SecureContext]
+interface ToolCancelEvent : Event {
+  constructor(DOMString type, optional ToolCancelEventInit eventInitDict = {});
+  readonly attribute DOMString toolName;
+  readonly attribute Element? element;
+};
+
+dictionary ToolCancelEventInit : EventInit {
+  DOMString toolName = "";
+  Element? element = null;
+};
+</xmp>
+
+<dl class="domintro" dfn-type=attribute dfn-for=ToolCancelEvent>
+  : <dfn>toolName</dfn>
+  :: Returns the name of the tool that was canceled.
+  : <dfn>element</dfn>
+  :: Returns the form element associated with the tool, if any.
+</dl>
 
 <h3 id="declarative-api">Declarative WebMCP</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -832,6 +832,11 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 
 1. [=Assert=]: |expectedTargetOrigin| is not an [=opaque origin=].
 
+1. Let |targetWindow| be |tool|'s {{RegisteredTool/window}}.
+
+1. Let |targetDocument| be |targetWindow|'s [=associated Document|associated
+   <code>Document</code>=].
+
 1. Let |promise| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 
 1. If |options|'s {{ModelContextExecuteToolOptions/signal}} [=map/exists=], then:
@@ -845,15 +850,13 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 
       1. [=Reject=] |promise| with |signal|'s [=AbortSignal/abort reason=].
 
+      1. [=Fire an event=] named {{ModelContext/toolcancel}} at |targetDocument|'s
+         [=Document/associated ModelContext|associated <code>ModelContext</code>=], using
+         {{ToolCancelEvent}}, with its {{ToolCancelEvent/toolName}} attribute initialized to
+         |tool|'s {{RegisteredTool/name}}.
+
       Issue(#48): Wire up |signal| to the tool execution callback in the tool host's document, so
-      that tool abort is communicated all the way through. This should also fire the
-      "<code>toolcanceled</code>" event in the target document. See also <a
-      href=https://github.com/webmachinelearning/webmcp/issues/146>issue #146</a>.
-
-1. Let |targetWindow| be |tool|'s {{RegisteredTool/window}}.
-
-1. Let |targetDocument| be |targetWindow|'s [=associated Document|associated
-   <code>Document</code>=].
+      that tool abort is communicated all the way through.
 
 1. Run the following steps [=in parallel=]:
 

--- a/index.bs
+++ b/index.bs
@@ -526,6 +526,8 @@ interface ModelContext : EventTarget {
   Promise<DOMString> executeTool(RegisteredTool tool, DOMString inputArguments, optional ModelContextExecuteToolOptions options = {});
 
   attribute EventHandler ontoolchange;
+  attribute EventHandler ontoolactivated;
+  attribute EventHandler ontoolcancel;
 };
 </xmp>
 
@@ -555,6 +557,13 @@ is a [=model context=] [=struct=] created alongside the {{ModelContext}}.
     <p>Executes a tool on the document it was registered on. Returns a promise that resolves to the
     stringified result of the tool's execution.</p>
   </dd>
+</dl>
+
+<dl dfn-type=attribute dfn-for=ModelContext>
+    : <dfn>ontoolactivated</dfn>
+    :: An [=event handler IDL attribute=] for the {{ModelContext/toolactivated}} event type.
+    : <dfn>ontoolcancel</dfn>
+    :: An [=event handler IDL attribute=] for the {{ModelContext/toolcancel}} event type.
 </dl>
 
 
@@ -1157,6 +1166,56 @@ dictionary RegisteredTool {
      {{ModelContextTool/annotations}}.
 </dl>
 
+
+<h4 id="tool-activated-event">ToolActivatedEvent Interface</h4>
+
+The {{ToolActivatedEvent}} interface represents a <dfn event for=ModelContext>toolactivated</dfn> event that is dispatched at {{Navigator/modelContext}} when a tool is invoked by an [=agent=].
+
+<xmp class="idl">
+[Exposed=Window, SecureContext]
+interface ToolActivatedEvent : Event {
+  constructor(DOMString type, optional ToolActivatedEventInit eventInitDict = {});
+  readonly attribute DOMString toolName;
+  readonly attribute Element? element;
+};
+
+dictionary ToolActivatedEventInit : EventInit {
+  DOMString toolName = "";
+  Element? element = null;
+};
+</xmp>
+
+<dl class="domintro" dfn-type=attribute dfn-for=ToolActivatedEvent>
+  : <dfn>toolName</dfn>
+  :: Returns the name of the tool that was activated.
+  : <dfn>element</dfn>
+  :: Returns the form element associated with the tool, if any.
+</dl>
+
+<h4 id="tool-cancel-event">ToolCancelEvent Interface</h4>
+
+The {{ToolCancelEvent}} interface represents a <dfn event for=ModelContext>toolcancel</dfn> event that is dispatched at {{Navigator/modelContext}} when a tool's invocation is canceled by an [=agent=].
+
+<xmp class="idl">
+[Exposed=Window, SecureContext]
+interface ToolCancelEvent : Event {
+  constructor(DOMString type, optional ToolCancelEventInit eventInitDict = {});
+  readonly attribute DOMString toolName;
+  readonly attribute Element? element;
+};
+
+dictionary ToolCancelEventInit : EventInit {
+  DOMString toolName = "";
+  Element? element = null;
+};
+</xmp>
+
+<dl class="domintro" dfn-type=attribute dfn-for=ToolCancelEvent>
+  : <dfn>toolName</dfn>
+  :: Returns the name of the tool that was canceled.
+  : <dfn>element</dfn>
+  :: Returns the form element associated with the tool, if any.
+</dl>
 
 <h3 id="declarative-api">Declarative WebMCP</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -411,7 +411,9 @@ The <dfn>imperative execute steps</dfn>, given a {{ModelContextTool}} |tool|, a 
 1. If |inputObject| [=Object type|is not an Object=] is false, then run |completionSteps| given null
    and false, and abort these steps.
 
-   Issue(#146): Specify and fire the "<code>toolactivated</code>" event.
+1. [=Fire an event=] named {{ModelContext/toolactivated}} at |targetDocument|'s [=Document/associated
+   ModelContext|associated <code>ModelContext</code>=], using {{ToolActivatedEvent}}, with its
+   {{ToolActivatedEvent/toolName}} attribute initialized to |tool|'s {{ModelContextTool/name}}.
 
 1. Let |toolPromise| be the result of [=invoke|invoking=] |tool|'s {{ModelContextTool/execute}} with
    |inputObject|.

--- a/index.bs
+++ b/index.bs
@@ -559,13 +559,6 @@ is a [=model context=] [=struct=] created alongside the {{ModelContext}}.
   </dd>
 </dl>
 
-<dl dfn-type=attribute dfn-for=ModelContext>
-    : <dfn>ontoolactivated</dfn>
-    :: An [=event handler IDL attribute=] for the {{ModelContext/toolactivated}} event type.
-    : <dfn>ontoolcancel</dfn>
-    :: An [=event handler IDL attribute=] for the {{ModelContext/toolcancel}} event type.
-</dl>
-
 
 <div algorithm>
 The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var>)</dfn> method steps are:
@@ -1169,7 +1162,7 @@ dictionary RegisteredTool {
 
 <h4 id="tool-activated-event">ToolActivatedEvent Interface</h4>
 
-The {{ToolActivatedEvent}} interface represents a <dfn event for=ModelContext>toolactivated</dfn> event that is dispatched at {{Navigator/modelContext}} when a tool is invoked by an [=agent=].
+The {{ToolActivatedEvent}} interface represents a {{ModelContext/toolactivated}} event that is dispatched at {{ModelContext}} when a tool is invoked by an [=agent=].
 
 <xmp class="idl">
 [Exposed=Window, SecureContext]
@@ -1194,7 +1187,7 @@ dictionary ToolActivatedEventInit : EventInit {
 
 <h4 id="tool-cancel-event">ToolCancelEvent Interface</h4>
 
-The {{ToolCancelEvent}} interface represents a <dfn event for=ModelContext>toolcancel</dfn> event that is dispatched at {{Navigator/modelContext}} when a tool's invocation is canceled by an [=agent=].
+The {{ToolCancelEvent}} interface represents a {{ModelContext/toolcancel}} event that is dispatched at {{ModelContext}} when a tool's invocation is canceled by an [=agent=].
 
 <xmp class="idl">
 [Exposed=Window, SecureContext]
@@ -1276,6 +1269,12 @@ that must be supported, as [=event handler IDL attributes=], by all {{ModelConte
     <tr>
       <td><dfn attribute for="ModelContext">ontoolchange</dfn>
       <td><dfn event for="ModelContext">toolchange</dfn>
+    <tr>
+      <td><dfn attribute for="ModelContext">ontoolactivated</dfn>
+      <td><dfn event for="ModelContext">toolactivated</dfn>
+    <tr>
+      <td><dfn attribute for="ModelContext">ontoolcancel</dfn>
+      <td><dfn event for="ModelContext">toolcancel</dfn>
 </table>
 
 <h3 id="permissions-policy">Permissions policy integration</h3>


### PR DESCRIPTION
Following https://github.com/webmachinelearning/webmcp/issues/126#issuecomment-4001724830, this PR adds new `ToolActivatedEvent` and `ToolCancelEvent` interfaces.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/webmcp/pull/146.html" title="Last updated on Aug 6, 2026, 9:49 AM UTC (1099a80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/146/0967151...beaufortfrancois:1099a80.html" title="Last updated on Aug 6, 2026, 9:49 AM UTC (1099a80)">Diff</a>