### PR TITLE
Scope `ModelContext` to `Document`, and handle detached documents

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -86,6 +86,14 @@ spec:html; type:dfn;
   text:browsing context group set
   text:unique internal value
 </pre>
+<pre class="anchors">
+spec: html; type: dfn; urlPrefix: https://html.spec.whatwg.org/C
+  text: create and initialize a Document object; url: initialise-the-document-object
+  # Because `text` and `url` are the same (modulo slashes), we should be able to
+  # exclude `url`. But the colon breaks the URL in `text`, forcing us to include
+  # `url`.
+  text:is initial about:blank; url: is-initial-about:blank
+</pre>
 
 <h2 id="intro">Introduction</h2>
 
@@ -112,6 +120,7 @@ A <dfn>model context</dfn> is a [=struct=] with the following [=struct/items=]:
   :: a [=map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are [=tool definition=]
      [=structs=].
 </dl>
+
 
 A <dfn>tool definition</dfn> is a [=struct=] with the following [=struct/items=]:
 
@@ -183,19 +192,40 @@ https://dlaliberte.github.io/bikeshed-intro/#a-strategy-for-incremental-developm
 
 <h3 id="navigator-extension">Extensions to the {{Navigator}} Interface</h3>
 
-The {{Navigator}} interface is extended to provide access to the {{ModelContext}}.
+Each {{Document}} object has an <dfn for=Document>associated {{ModelContext}}</dfn>, which is a
+{{ModelContext}} object.
+
+Upon creation of the {{Document}} object, its [=Document/associated ModelContext|associated
+<code>ModelContext</code>=] must be set to a [=new=] {{ModelContext}} object created in the
+{{Document}}'s [=relevant realm=].
+
+The {{Navigator}} interface provides access to a {{Document}}'s [=Document/associated
+ModelContext|associated <code>ModelContext</code>=] through its {{Navigator/modelContext}}
+attribute.
+
+Note: The reason {{ModelContext}} is owned by {{Document}} instead of {{Navigator}} is to ensure
+that tools registered within an [=is initial about:blank|initial <code>about:blank</code>=]
+{{Document}} are not available to the subsequent [=same origin=] {{Document}} that results from
+navigating away from the initial {{Document}}. This is crucial, since these two {{Document}}s share
+the same {{Window}} and {{Navigator}} objects. See step 6.1 in [=create and initialize a Document
+object|create and initialize a <code>Document</code> object=].
+
+<hr>
 
 <xmp class="idl">
 partial interface Navigator {
-  [SecureContext, SameObject] readonly attribute ModelContext modelContext;
+  [SecureContext] readonly attribute ModelContext? modelContext;
 };
 </xmp>
 
-Each {{Navigator}} object has an associated <dfn for=Navigator>modelContext</dfn>, which is a
-{{ModelContext}} instance created alongside the {{Navigator}}.
-
 <div algorithm>
-The <dfn attribute for=Navigator>modelContext</dfn> getter steps are to return [=this=]'s [=Navigator/modelContext=].
+The <dfn attribute for=Navigator>modelContext</dfn> getter steps are:
+
+1. If [=this=]'s [=relevant global object=]'s [=Window/browsing context=] is null, then return null.
+
+1. Return [=this=]'s [=relevant global object=]'s [=associated Document=]'s [=Document/associated
+   ModelContext|associated <code>ModelContext</code>=] object.
+
 </div>
 
 <h3 id="model-context-container">ModelContext Interface</h3>
@@ -515,8 +545,8 @@ steps:
 
      1. Let |id| be |document|'s [=Document/unique ID=].
 
-     1. Set |observation|'s [=observation/tool map=][|id|] = |document|'s [=relevant global
-        object=]'s {{Navigator}}'s [=Navigator/modelContext=]'s [=ModelContext/internal context=]'s
+     1. Set |observation|'s [=observation/tool map=][|id|] = |document|'s [=Document/associated
+        ModelContext|associated <code>ModelContext</code>=]'s [=ModelContext/internal context=]'s
         [=model context/tool map=]'s [=map/values=], which are [=tool definitions=].
 
 1. Perform any [=implementation-defined=] steps to add anything to |observation| that the [=user

--- a/index.bs
+++ b/index.bs
@@ -93,6 +93,7 @@ spec: html; type: dfn; urlPrefix: https://html.spec.whatwg.org/C
   # exclude `url`. But the colon breaks the URL in `text`, forcing us to include
   # `url`.
   text:is initial about:blank; url: is-initial-about:blank
+  text: associated Navigator
 </pre>
 
 <h2 id="intro">Introduction</h2>
@@ -192,39 +193,46 @@ https://dlaliberte.github.io/bikeshed-intro/#a-strategy-for-incremental-developm
 
 <h3 id="navigator-extension">Extensions to the {{Navigator}} Interface</h3>
 
-Each {{Document}} object has an <dfn for=Document>associated {{ModelContext}}</dfn>, which is a
+Each {{Navigator}} object has an <dfn for=Navigator>associated {{ModelContext}}</dfn>, which is a
 {{ModelContext}} object.
 
-Upon creation of the {{Document}} object, its [=Document/associated ModelContext|associated
+Upon creation of the {{Navigator}} object, its [=Navigator/associated ModelContext|associated
 <code>ModelContext</code>=] must be set to a [=new=] {{ModelContext}} object created in the
-{{Document}}'s [=relevant realm=].
+{{Navigator}}'s [=relevant realm=]. It only ever changes from one `{{ModelContext}}` instance to
+another the first time the {{Navigator/modelContext}} getter is accessed after a navigation away
+from the [=is initial about:blank|initial <code>about:blank</code>=],
 
-The {{Navigator}} interface provides access to a {{Document}}'s [=Document/associated
-ModelContext|associated <code>ModelContext</code>=] through its {{Navigator/modelContext}}
-attribute.
-
-Note: The reason {{ModelContext}} is owned by {{Document}} instead of {{Navigator}} is to ensure
-that tools registered within an [=is initial about:blank|initial <code>about:blank</code>=]
-{{Document}} are not available to the subsequent [=same origin=] {{Document}} that results from
-navigating away from the initial {{Document}}. This is crucial, since these two {{Document}}s share
-the same {{Window}} and {{Navigator}} objects. See step 6.1 in [=create and initialize a Document
+Note: The reason a {{Navigator}}'s [=Navigator/associated ModelContext|associated
+<code>ModelContext</code>=] changes is as follows: {{ModelContext}} is a {{Document}}-scoped
+registry of tools, but because it is accessed from an object that is shared between two {{Document}}
+objects, it gets updated when the {{Navigator}}'s [=relevant global object=]'s
+[=associated Document|associated <code>Document</code>=] gets updated, to ensure that tools registered within the [=is
+initial about:blank|initial <code>about:blank</code>=] {{Document}} do not mix with tools in the
+subsequent [=same origin=] {{Document}} See step 6.1 in [=create and initialize a Document
 object|create and initialize a <code>Document</code> object=].
+
+Each {{ModelContext}} object has a <dfn for=ModelContext>creation {{Document}}</dfn>, which is its
+[=relevant global object=]s [=associated Document|associated <code>Document</code>=] at the time of creation.
 
 <hr>
 
 <xmp class="idl">
 partial interface Navigator {
-  [SecureContext] readonly attribute ModelContext? modelContext;
+  [SecureContext] readonly attribute ModelContext modelContext;
 };
 </xmp>
 
 <div algorithm>
 The <dfn attribute for=Navigator>modelContext</dfn> getter steps are:
 
-1. If [=this=]'s [=relevant global object=]'s [=Window/browsing context=] is null, then return null.
+1. If [=this=]'s [=Navigator/associated ModelContext|associated <code>ModelContext</code>=]'s
+   [=ModelContext/creation Document| creation <code>Document</code>=] does not equal [=this=]'s
+   [=relevant global object=]'s [=associated Document|associated <code>Document</code>=], then set
+   [=this=]'s [=Navigator/associated ModelContext|associated <code>ModelContext</code>=] to a
+   [=new=] {{ModelContext}} object.
 
-1. Return [=this=]'s [=relevant global object=]'s [=associated Document=]'s [=Document/associated
-   ModelContext|associated <code>ModelContext</code>=] object.
+1. Return [=this=]'s [=Navigator/associated ModelContext|associated <code>ModelContext</code>=]
+   object.
 
 </div>
 
@@ -545,9 +553,11 @@ steps:
 
      1. Let |id| be |document|'s [=Document/unique ID=].
 
-     1. Set |observation|'s [=observation/tool map=][|id|] = |document|'s [=Document/associated
-        ModelContext|associated <code>ModelContext</code>=]'s [=ModelContext/internal context=]'s
-        [=model context/tool map=]'s [=map/values=], which are [=tool definitions=].
+     1. Set |observation|'s [=observation/tool map=][|id|] = |document|'s [=relevant global
+        object=]'s [=associated Navigator|associated <code>Navigator</code>=]'s
+        [=Navigator/associated ModelContext|associated <code>ModelContext</code>=]'s
+        [=ModelContext/internal context=]'s [=model context/tool map=]'s [=map/values=], which are
+        [=tool definitions=].
 
 1. Perform any [=implementation-defined=] steps to add anything to |observation| that the [=user
    agent=] might deem useful or necessary, besides just populating the [=observation/tool map=].


### PR DESCRIPTION
This PR does two things:
 - Scopes the `ModelContext` object to `Document` instead of `Navigator`, and explains why.
 - Makes the `modelContext` attribute return null when the document is detached (by checking when the Window's browsing context is null). This matches the behavior of the `contentWindow` and [`contentDocument` getters](https://html.spec.whatwg.org/#concept-bcc-content-document)—return nothing, even if those objects are allocated and kept alive by other references, in the detached document case.

Note that this PR does not handle the "document not fully active" case, which covers detached documents *and* documents in the bf-cache. Non-fully active documents probably shouldn't impact the `modelContext` getter—it seems weird for getters like that to return different values based on whether the document is in the bf-cache—but rather need special behavior in the `registerTool()` method, and the coming `getTools()` and `executeTool()` methods.

This PR mostly addresses https://github.com/webmachinelearning/webmcp/issues/173, with the exception of considering moving the API to `self`, from `navigator`. As much as I want to do this, I'm sympathetic to https://github.com/w3ctag/design-principles/issues/426#issuecomment-3824607888, so for now I'm leaning towards not moving it. So I'll say that this PR closes https://github.com/webmachinelearning/webmcp/issues/173.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/pull/177.html" title="Last updated on May 18, 2026, 8:24 PM UTC (f11b3da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/177/a99ffd2...f11b3da.html" title="Last updated on May 18, 2026, 8:24 PM UTC (f11b3da)">Diff</a>