### PR TITLE
Toolchange event and permissions policy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -324,7 +324,7 @@ The {{ModelContext}} interface provides methods for web applications to register
 
 <xmp class="idl">
 [Exposed=Window, SecureContext]
-interface ModelContext {
+interface ModelContext : EventTarget {
   undefined registerTool(ModelContextTool tool, optional ModelContextRegisterToolOptions options = {});
 
   attribute EventHandler ontoolchange;

--- a/index.bs
+++ b/index.bs
@@ -101,6 +101,9 @@ spec: html; type: dfn; urlPrefix: https://html.spec.whatwg.org/C
   # `url`.
   text:is initial about:blank; url: is-initial-about:blank
   text: associated Navigator
+spec: SECURE-CONTEXTS; urlPrefix: https://w3c.github.io/webappsec-secure-contexts/
+  type: abstract-op
+    text: is origin potentially trustworthy?; url: is-origin-trustworthy
 </pre>
 
 <h2 id="intro">Introduction</h2>
@@ -402,8 +405,9 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 
           1. Let |parsedURL| be the result of running the [=URL parser=] on |origin|.
 
-          1. If |parsedURL| is failure or its [=url/scheme=] is not "<code>https</code>", then
-             [=exception/throw=] an "{{SecurityError}}" {{DOMException}}.
+          1. If |parsedURL| is failure or its [=url/origin=] is not [$is origin potentially
+             trustworthy?|potentially trustworthy$], then [=exception/throw=] an "{{SecurityError}}"
+             {{DOMException}}.
 
           1. [=list/Append=] |parsedURL|'s [=url/origin=] to |exposed origins|.
 

--- a/index.bs
+++ b/index.bs
@@ -609,8 +609,7 @@ loop=], that get registered with the APIs in this specification.
 
 The [=user agent=]'s [=browser agent=] runs [=in parallel=] to any [=event loops=] associated
 with a {{ModelContext}} [=relevant global object=]. Steps running on the [=browser agent=] get
-queued on its <dfn>webmcp parallel queue</dfn>, which is the result of [=starting a new parallel
-queue=].
+queued on its <dfn>AI agent queue</dfn>, which is the result of [=starting a new parallel queue=].
 
 Conversely, steps queued *from* the [=browser agent=] onto the [=event loop=] of a given
 {{ModelContext}} object (i.e., the "main thread" where JavaScript runs) are queued on its [=relevant
@@ -646,7 +645,7 @@ in the Chromium project for an example of what might contribute to an observatio
 To <dfn>perform an observation</dfn> given a [=top-level traversable=] |traversable|, run these
 steps:
 
-1. [=Assert=]: This algorithm is running in the [=browser agent=]'s [=webmcp parallel queue=].
+1. [=Assert=]: This algorithm is running in the [=browser agent=]'s [=AI agent queue=].
 
 1. [=Assert=]: |traversable|'s [=navigable/active document=] is not [=Document/fully active=].
 
@@ -691,10 +690,10 @@ Each {{Document}} object has a <dfn for=Document>unique ID</dfn>, which is a [=u
 value=].
 
 The times at which a [=browser agent=] [=performs an observation=] are [=implementation-defined=].
-A [=browser agent=] may [=parallel queue/enqueue steps=] to the [=webmcp parallel queue=] to
-[=perform an observation=] given any [=top-level browsing context=] in the [=user agent=] [=browsing
-context group set=], at any time, although implementations typically reserve this operation for when
-the user is interacting with a [=browser agent=] while web content is in view.
+A [=browser agent=] may [=parallel queue/enqueue steps=] to the [=AI agent queue=] to [=perform an
+observation=] given any [=top-level browsing context=] in the [=user agent=] [=browsing context
+group set=], at any time, although implementations typically reserve this operation for when the
+user is interacting with a [=browser agent=] while web content is in view.
 
 
 <h2 id="security-privacy">Security and privacy considerations</h2>

--- a/index.bs
+++ b/index.bs
@@ -78,6 +78,13 @@ p + dl.props { margin-top: -0.5em; }
 [data-algorithm] [data-algorithm] {
   margin: 1em 0;
 }
+
+/* Table styling definitions from https://resources.whatwg.org/standard.css */
+table { border-collapse: collapse; border-style: hidden hidden none hidden; margin: 1.25em 0; }
+table thead, table tbody { border-bottom: solid; }
+table tbody th { text-align: left; }
+table tbody th:first-child { border-left: solid; }
+table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
 </style>
 
 <pre class="link-defaults">
@@ -93,7 +100,7 @@ spec: html; type: dfn; urlPrefix: https://html.spec.whatwg.org/C
   # exclude `url`. But the colon breaks the URL in `text`, forcing us to include
   # `url`.
   text:is initial about:blank; url: is-initial-about:blank
-  text: associated Navigator
+  text:associated Navigator
 </pre>
 
 <h2 id="intro">Introduction</h2>
@@ -171,6 +178,69 @@ A <dfn>tool definition</dfn> is a [=struct=] with the following [=struct/items=]
 </dl>
 
 <div algorithm>
+To <dfn>notify documents of a tool change</dfn> given a {{Document}} |toolOwner| and a [=list=] of
+[=origins=] |exposedOrigins|, run these steps:
+
+1. [=Assert=]: these steps are running on |toolOwner|'s [=relevant agent=]'s [=agent/event loop=].
+
+1. Let |navigablesToNotify| be |toolOwner|'s [=node navigable=]'s [=navigable/traversable
+   navigable=]'s [=Document/descendant navigables=].
+
+1. [=list/For each=] |navigable| of |navigablesToNotify|:
+
+     1. Let |targetDocument| be |navigable|'s [=navigable/active document=].
+
+     1. If |targetDocument| is not [=allowed to use=] the "{{tools}}" feature, then
+        [=iteration/continue=].
+
+     1. If [=tool is visible to an origin=] given |exposedOrigins| and |targetDocument|'s
+        [=Document/origin=], then [=queue a global task=] on the [=webmcp task source=] given
+        |targetDocument|'s [=relevant global object=] to [=fire an event=] named
+        {{ModelContext/toolchange}} at |targetDocument|'s [=relevant global object=]'s [=associated
+        Navigator|associated <code>Navigator</code>=]'s [=Navigator/associated
+        ModelContext|associated <code>ModelContext</code>=].
+
+<div class=example id=notify-task-ordering>
+  <p>This algorithm's use of the [=webmcp task source=] means that the timing between firing the
+  {{ModelContext/toolchange}} event, and other tasks queued after this algorithm, cannot be relied
+  upon. For example:</p>
+
+  <xmp class=language-js>
+  navigator.modelContext.ontoolchange = e => console.log('Parent toolchange');
+  iframe.contentWindow.navigator.modelContext.ontoolchange = e => console.log('Child toolchange');
+
+  // Queues a task to fire `toolchange`, on the `webmcp task source`.
+  navigator.modelContext.registerTool({
+    name: "tool_name",
+    description: "tool_desc",
+    execute: async () => {}
+  });
+
+  // Queues a task on the `timer task source`.
+  setTimeout(() => console.log('Post-register task'));
+
+  // `Parent toolchange` will always log before `Child toolchange`.
+  // But `Post-register task` can log before, in between, or after both.
+  </xmp>
+</div>
+
+</div>
+
+<div algorithm>
+To determine if a <dfn>tool is visible to an origin</dfn> given a [=list=] of
+[=origins=] |exposedOrigins| and an [=origin=] |targetOrigin|, run these steps:
+
+1. [=list/For each=] |origin| of |exposedOrigins|:
+
+     1. If |targetOrigin| is [=same origin=] with |origin|, then return true.
+
+1. Return false.
+
+</div>
+
+<hr>
+
+<div algorithm>
 To <dfn for="model context">unregister a tool</dfn> for a [=model context=] given a [=string=]
 |tool name|, run these steps:
 
@@ -244,6 +314,8 @@ The {{ModelContext}} interface provides methods for web applications to register
 [Exposed=Window, SecureContext]
 interface ModelContext {
   undefined registerTool(ModelContextTool tool, optional ModelContextRegisterToolOptions options = {});
+
+  attribute EventHandler ontoolchange;
 };
 </xmp>
 
@@ -264,6 +336,15 @@ is a [=model context=] [=struct=] created alongside the {{ModelContext}}.
 
 <div algorithm>
 The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var>)</dfn> method steps are:
+
+1. Let |toolOwner| be [=this=]'s [=relevant global object=]'s [=associated Document|associated
+   <code>Document</code>=].
+
+1. If |toolOwner| is not [=Document/fully active=], then [=exception/throw=] an
+   "{{InvalidStateError}}" {{DOMException}}.
+
+1. If |toolOwner| is not [=allowed to use=] the "{{tools}}" feature, then [=exception/throw=] a
+   "{{NotAllowedError}}" {{DOMException}}.
 
 1. Let |tool map| be [=this=]'s [=ModelContext/internal context=]'s [=model context/tool map=].
 
@@ -342,6 +423,8 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
    :: |untrusted content hint|
 
 1. Set [=this=]'s [=ModelContext/internal context=][|tool name|] to |tool definition|.
+
+1. Run the [=notify documents of a tool change=] given |toolOwner| and an empty [=list=].
 
 </div>
 
@@ -493,6 +576,30 @@ The <dfn>synthesize a declarative JSON Schema object algorithm</dfn>, given a <{
 }
 </pre>
 
+<h3 id="events">Events</h3>
+
+The following are the [=event handlers=] (and their corresponding [=event handler event types=])
+that must be supported, as [=event handler IDL attributes=], by all {{ModelContext}} objects:
+
+<table>
+  <thead>
+    <tr>
+      <th>[=Event handler=]
+      <th>[=Event handler event type=]
+  <tbody>
+    <tr>
+      <td><dfn attribute for="ModelContext">ontoolchange</dfn>
+      <td><dfn event for="ModelContext">toolchange</dfn>
+</table>
+
+<h3 id="permissions-policy">Permissions policy integration</h3>
+
+Access to the APIs in this specification is gated behind the [=policy-controlled feature=] "<dfn
+permission>tools</dfn>", which has a [=policy-controlled feature/default allowlist=] of
+<code>[=default allowlist/'self'=]</code>.
+
+This.
+
 <h2 id="interaction-with-agents">Interaction with agents</h2>
 
 <h3 id="event-loop">Event loop integration</h3>
@@ -502,11 +609,12 @@ loop=], that get registered with the APIs in this specification.
 
 The [=user agent=]'s [=browser agent=] runs [=in parallel=] to any [=event loops=] associated
 with a {{ModelContext}} [=relevant global object=]. Steps running on the [=browser agent=] get
-queued on its <dfn>AI agent queue</dfn>, which is the result of [=starting a new parallel queue=].
+queued on its <dfn>webmcp parallel queue</dfn>, which is the result of [=starting a new parallel
+queue=].
 
 Conversely, steps queued *from* the [=browser agent=] onto the [=event loop=] of a given
 {{ModelContext}} object (i.e., the "main thread" where JavaScript runs) are queued on its [=relevant
-global object=]'s <dfn noexport>tool calling task source</dfn>.
+global object=]'s <dfn noexport>webmcp task source</dfn>.
 
 <h3 id="observations">Page observations</h3>
 
@@ -538,7 +646,7 @@ in the Chromium project for an example of what might contribute to an observatio
 To <dfn>perform an observation</dfn> given a [=top-level traversable=] |traversable|, run these
 steps:
 
-1. [=Assert=]: This algorithm is running in the [=browser agent=]'s [=AI agent queue=].
+1. [=Assert=]: This algorithm is running in the [=browser agent=]'s [=webmcp parallel queue=].
 
 1. [=Assert=]: |traversable|'s [=navigable/active document=] is not [=Document/fully active=].
 
@@ -583,10 +691,10 @@ Each {{Document}} object has a <dfn for=Document>unique ID</dfn>, which is a [=u
 value=].
 
 The times at which a [=browser agent=] [=performs an observation=] are [=implementation-defined=].
-A [=browser agent=] may [=parallel queue/enqueue steps=] to the [=AI agent queue=] to [=perform an
-observation=] given any [=top-level browsing context=] in the [=user agent=] [=browsing context
-group set=], at any time, although implementations typically reserve this operation for when the
-user is interacting with a [=browser agent=] while web content is in view.
+A [=browser agent=] may [=parallel queue/enqueue steps=] to the [=webmcp parallel queue=] to
+[=perform an observation=] given any [=top-level browsing context=] in the [=user agent=] [=browsing
+context group set=], at any time, although implementations typically reserve this operation for when
+the user is interacting with a [=browser agent=] while web content is in view.
 
 
 <h2 id="security-privacy">Security and privacy considerations</h2>

--- a/index.bs
+++ b/index.bs
@@ -399,20 +399,6 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
      </ol>
    </div>
 
-1. Let |exposed origins| be an empty [=list=] of [=origins=].
-
-1. If |options|'s {{ModelContextRegisterToolOptions/exposedTo}} [=map/exists=], then:
-
-     1. [=list/For each=] |origin| of |options|'s {{ModelContextRegisterToolOptions/exposedTo}}:
-
-          1. Let |parsedURL| be the result of running the [=URL parser=] on |origin|.
-
-          1. If |parsedURL| is failure or its [=url/origin=] is not [$is origin potentially
-             trustworthy?|potentially trustworthy$], then [=exception/throw=] an "{{SecurityError}}"
-             {{DOMException}}.
-
-          1. [=list/Append=] |parsedURL|'s [=url/origin=] to |exposed origins|.
-
 1. Let |read-only hint| be true if |tool|'s {{ModelContextTool/annotations}} [=map/exists=] and
    its {{ToolAnnotations/readOnlyHint}} is true. Otherwise, let it be false.
 
@@ -429,6 +415,20 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 
    1. [=AbortSignal/add|Add an abort algorithm=] to |signal| that [=model context/unregisters a
       tool=] given [=this=] and |tool name|.
+
+1. Let |exposed origins| be an empty [=list=] of [=origins=].
+
+1. If |options|'s {{ModelContextRegisterToolOptions/exposedTo}} [=map/exists=], then:
+
+     1. [=list/For each=] |origin| of |options|'s {{ModelContextRegisterToolOptions/exposedTo}}:
+
+          1. Let |parsedURL| be the result of running the [=URL parser=] on |origin|.
+
+          1. If |parsedURL| is failure or its [=url/origin=] is not [$is origin potentially
+             trustworthy?|potentially trustworthy$], then [=exception/throw=] an "{{SecurityError}}"
+             {{DOMException}}.
+
+          1. [=list/Append=] |parsedURL|'s [=url/origin=] to |exposed origins|.
 
 1. Let |tool definition| be a new [=tool definition=], with the following [=struct/items=]:
 

--- a/index.bs
+++ b/index.bs
@@ -180,6 +180,8 @@ A <dfn>tool definition</dfn> is a [=struct=] with the following [=struct/items=]
   :: a [=list=] or [=origins=], initially [=list/empty=].
 </dl>
 
+<hr>
+
 <div algorithm>
 To <dfn>notify documents of a tool change</dfn> given a {{Document}} |toolOwner| and a [=list=] of
 [=origins=] |exposed origins|, run these steps:
@@ -241,17 +243,24 @@ To determine if a <dfn>tool is visible to an origin</dfn> given a [=list=] of
 
 </div>
 
-<hr>
-
 <div algorithm>
-To <dfn for="model context">unregister a tool</dfn> for a [=model context=] given a [=string=]
-|tool name|, run these steps:
+To <dfn for="model context">unregister a tool</dfn> given a {{ModelContext}} |modelContext| and a
+[=string=] |tool name|, run these steps:
 
-1. Let |tool map| be the associated [=model context=]'s [=model context/tool map=].
+1. [=Assert=]: these steps are running on |modelContext|'s [=relevant agent=]'s [=agent/event
+   loop=].
+
+1. Let |tool map| be |modelContext|'s [=ModelContext/internal context=]'s [=model context/tool
+   map=].
 
 1. [=Assert=] |tool map|[|tool name|] [=map/exists=].
 
+1. Let |exposed origins| be |tool map|[|tool name|]'s [=tool definition/exposed origins=].
+
 1. [=map/Remove=] |tool map|[|tool name|].
+
+1. Run [=notify documents of a tool change=] given |modelContext|'s [=relevant global object=]'s
+   [=associated Document|associated <code>Document</code>=] and |exposed origins|.
 
 </div>
 
@@ -413,7 +422,7 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
       [=AbortSignal/aborted=], and return.
 
    1. [=AbortSignal/add|Add an abort algorithm=] to |signal| that [=model context/unregisters a
-      tool=] from [=this=] [=ModelContext/internal context=] given |tool name|.
+      tool=] from [=this=] given |tool name|.
 
 1. Let |tool definition| be a new [=tool definition=], with the following [=struct/items=]:
 
@@ -443,7 +452,7 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 
 1. Set [=this=]'s [=ModelContext/internal context=][|tool name|] to |tool definition|.
 
-1. Run the [=notify documents of a tool change=] given |toolOwner| and an empty [=list=].
+1. Run [=notify documents of a tool change=] given |toolOwner| and |exposed origins|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -175,11 +175,14 @@ A <dfn>tool definition</dfn> is a [=struct=] with the following [=struct/items=]
 
   : <dfn>untrusted content hint</dfn>
   :: a [=boolean=], initially false.
+
+  : <dfn>exposed origins</dfn>
+  :: a [=list=] or [=origins=], initially [=list/empty=].
 </dl>
 
 <div algorithm>
 To <dfn>notify documents of a tool change</dfn> given a {{Document}} |toolOwner| and a [=list=] of
-[=origins=] |exposedOrigins|, run these steps:
+[=origins=] |exposed origins|, run these steps:
 
 1. [=Assert=]: these steps are running on |toolOwner|'s [=relevant agent=]'s [=agent/event loop=].
 
@@ -193,7 +196,7 @@ To <dfn>notify documents of a tool change</dfn> given a {{Document}} |toolOwner|
      1. If |targetDocument| is not [=allowed to use=] the "{{tools}}" feature, then
         [=iteration/continue=].
 
-     1. If [=tool is visible to an origin=] given |exposedOrigins| and |targetDocument|'s
+     1. If [=tool is visible to an origin=] given |exposed origins| and |targetDocument|'s
         [=Document/origin=], then [=queue a global task=] on the [=webmcp task source=] given
         |targetDocument|'s [=relevant global object=] to [=fire an event=] named
         {{ModelContext/toolchange}} at |targetDocument|'s [=relevant global object=]'s [=associated
@@ -228,9 +231,9 @@ To <dfn>notify documents of a tool change</dfn> given a {{Document}} |toolOwner|
 
 <div algorithm>
 To determine if a <dfn>tool is visible to an origin</dfn> given a [=list=] of
-[=origins=] |exposedOrigins| and an [=origin=] |targetOrigin|, run these steps:
+[=origins=] |exposed origins| and an [=origin=] |targetOrigin|, run these steps:
 
-1. [=list/For each=] |origin| of |exposedOrigins|:
+1. [=list/For each=] |origin| of |exposed origins|:
 
      1. If |targetOrigin| is [=same origin=] with |origin|, then return true.
 
@@ -382,6 +385,19 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
      </ol>
    </div>
 
+1. Let |exposed origins| be an empty [=list=] of [=origins=].
+
+1. If |options|'s {{ModelContextRegisterToolOptions/exposedTo}} [=map/exists=], then:
+
+     1. [=list/For each=] |origin| of |options|'s {{ModelContextRegisterToolOptions/exposedTo}}:
+
+          1. Let |parsedURL| be the result of running the [=URL parser=] on |origin|.
+
+          1. If |parsedURL| is failure or its [=url/scheme=] is not "<code>https</code>", then
+             [=exception/throw=] an "{{SecurityError}}" {{DOMException}}.
+
+          1. [=list/Append=] |parsedURL|'s [=url/origin=] to |exposed origins|.
+
 1. Let |read-only hint| be true if |tool|'s {{ModelContextTool/annotations}} [=map/exists=] and
    its {{ToolAnnotations/readOnlyHint}} is true. Otherwise, let it be false.
 
@@ -421,6 +437,9 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 
    : [=tool definition/untrusted content hint=]
    :: |untrusted content hint|
+
+   : [=tool definition/exposed origins=]
+   :: |exposed origins|
 
 1. Set [=this=]'s [=ModelContext/internal context=][|tool name|] to |tool definition|.
 
@@ -508,6 +527,7 @@ definition itself.
 <xmp class="idl">
 dictionary ModelContextRegisterToolOptions {
   AbortSignal signal;
+  sequence<USVString> exposedTo;
 };
 </xmp>
 
@@ -515,6 +535,12 @@ dictionary ModelContextRegisterToolOptions {
   <dt><code><var ignore>tool</var>["{{ModelContextRegisterToolOptions/signal}}"]</code></dt>
   <dd>
     <p>An {{AbortSignal}} that unregisters the tool when aborted.
+  </dd>
+
+  <dt><code><var ignore>exposedTo</var>["{{ModelContextRegisterToolOptions/exposedTo}}"]</code></dt>
+  <dd>
+    <p>An array of origins that control which documents this tool is exposed to, in the current
+    document's tree.
   </dd>
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -633,8 +633,6 @@ Access to the APIs in this specification is gated behind the [=policy-controlled
 permission>tools</dfn>", which has a [=policy-controlled feature/default allowlist=] of
 <code>[=default allowlist/'self'=]</code>.
 
-This.
-
 <h2 id="interaction-with-agents">Interaction with agents</h2>
 
 <h3 id="event-loop">Event loop integration</h3>

--- a/index.bs
+++ b/index.bs
@@ -186,12 +186,12 @@ A <dfn>tool definition</dfn> is a [=struct=] with the following [=struct/items=]
 <hr>
 
 <div algorithm>
-To <dfn>notify documents of a tool change</dfn> given a {{Document}} |toolOwner| and a [=list=] of
+To <dfn>notify documents of a tool change</dfn> given a {{Document}} |tool owner| and a [=list=] of
 [=origins=] |exposed origins|, run these steps:
 
-1. [=Assert=]: these steps are running on |toolOwner|'s [=relevant agent=]'s [=agent/event loop=].
+1. [=Assert=]: these steps are running on |tool owner|'s [=relevant agent=]'s [=agent/event loop=].
 
-1. Let |navigablesToNotify| be |toolOwner|'s [=node navigable=]'s [=navigable/traversable
+1. Let |navigablesToNotify| be |tool owner|'s [=node navigable=]'s [=navigable/traversable
    navigable=]'s [=Document/descendant navigables=].
 
 1. [=list/For each=] |navigable| of |navigablesToNotify|:
@@ -201,11 +201,11 @@ To <dfn>notify documents of a tool change</dfn> given a {{Document}} |toolOwner|
      1. If |targetDocument| is not [=allowed to use=] the "{{tools}}" feature, then
         [=iteration/continue=].
 
-     1. If [=tool is visible to an origin=] given |exposed origins| and |targetDocument|'s
-        [=Document/origin=], then [=queue a global task=] on the [=webmcp task source=] given
-        |targetDocument|'s [=relevant global object=] to [=fire an event=] named
-        {{ModelContext/toolchange}} at |targetDocument|'s [=relevant global object=]'s [=associated
-        Navigator|associated <code>Navigator</code>=]'s [=Navigator/associated
+     1. If [=tool is visible to an origin=] given |tool owner|'s [=Document/origin=], |exposed
+        origins|, and |targetDocument|'s [=Document/origin=], then [=queue a global task=] on the
+        [=webmcp task source=] given |targetDocument|'s [=relevant global object=] to [=fire an
+        event=] named {{ModelContext/toolchange}} at |targetDocument|'s [=relevant global object=]'s
+        [=associated Navigator|associated <code>Navigator</code>=]'s [=Navigator/associated
         ModelContext|associated <code>ModelContext</code>=].
 
 <div class=example id=notify-task-ordering>
@@ -235,12 +235,14 @@ To <dfn>notify documents of a tool change</dfn> given a {{Document}} |toolOwner|
 </div>
 
 <div algorithm>
-To determine if a <dfn>tool is visible to an origin</dfn> given a [=list=] of
-[=origins=] |exposed origins| and an [=origin=] |targetOrigin|, run these steps:
+To determine if a <dfn>tool is visible to an origin</dfn> given an [=origin=] |tool owner origin|,
+a [=list=] of [=origins=] |exposed origins|, and an [=origin=] |target origin|, run these steps:
+
+1. If |tool owner origin| is [=same origin=] with |target origin|, then return true.
 
 1. [=list/For each=] |origin| of |exposed origins|:
 
-     1. If |targetOrigin| is [=same origin=] with |origin|, then return true.
+     1. If |target origin| is [=same origin=] with |origin|, then return true.
 
 1. Return false.
 
@@ -352,13 +354,13 @@ is a [=model context=] [=struct=] created alongside the {{ModelContext}}.
 <div algorithm>
 The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var>)</dfn> method steps are:
 
-1. Let |toolOwner| be [=this=]'s [=relevant global object=]'s [=associated Document|associated
+1. Let |tool owner| be [=this=]'s [=relevant global object=]'s [=associated Document|associated
    <code>Document</code>=].
 
-1. If |toolOwner| is not [=Document/fully active=], then [=exception/throw=] an
+1. If |tool owner| is not [=Document/fully active=], then [=exception/throw=] an
    "{{InvalidStateError}}" {{DOMException}}.
 
-1. If |toolOwner| is not [=allowed to use=] the "{{tools}}" feature, then [=exception/throw=] a
+1. If |tool owner| is not [=allowed to use=] the "{{tools}}" feature, then [=exception/throw=] a
    "{{NotAllowedError}}" {{DOMException}}.
 
 1. Let |tool map| be [=this=]'s [=ModelContext/internal context=]'s [=model context/tool map=].
@@ -456,7 +458,7 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 
 1. Set [=this=]'s [=ModelContext/internal context=][|tool name|] to |tool definition|.
 
-1. Run [=notify documents of a tool change=] given |toolOwner| and |exposed origins|.
+1. Run [=notify documents of a tool change=] given |tool owner| and |exposed origins|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -422,7 +422,7 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
       [=AbortSignal/aborted=], and return.
 
    1. [=AbortSignal/add|Add an abort algorithm=] to |signal| that [=model context/unregisters a
-      tool=] from [=this=] given |tool name|.
+      tool=] given [=this=] and |tool name|.
 
 1. Let |tool definition| be a new [=tool definition=], with the following [=struct/items=]:
 

--- a/index.bs
+++ b/index.bs
@@ -100,7 +100,7 @@ spec: html; type: dfn; urlPrefix: https://html.spec.whatwg.org/C
   # exclude `url`. But the colon breaks the URL in `text`, forcing us to include
   # `url`.
   text:is initial about:blank; url: is-initial-about:blank
-  text:associated Navigator
+  text: associated Navigator
 </pre>
 
 <h2 id="intro">Introduction</h2>


### PR DESCRIPTION
This PR contributes to the following issues:
 - https://github.com/webmachinelearning/webmcp/issues/57
 - https://github.com/webmachinelearning/webmcp/issues/117
 - https://github.com/webmachinelearning/webmcp/issues/159
 - https://github.com/webmachinelearning/webmcp/issues/160
 - https://github.com/webmachinelearning/webmcp/issues/178

So far this PR only works on the `registerTool()` API, bringing it up to speed with the web platform tests in https://github.com/web-platform-tests/wpt/tree/master/webmcp/imperative. Subsequent PRs will introduce the `getTools()` and `executeTool()`, to fully close the above issues.

This PR introduces:
 - `registerTool()` changes:
    - The `exposeTo` origin list as a tool registration option
    - Scheme checks for `https` exposed origins; an exception is thrown otherwise
    - Permissions policy check
 - The `toolchange` event name
 - The "notify documents of a tool change" algorithm which fires `toolchange` in all documents in the tree that a tool changes in, in order
 - Renames the "tool calling task source" to "webmcp task source", to reflect the fact that the entire spec will use this not just for tool calling
    - Also adds an example of scheduling guarantees
 - The "tools" permissions policy
 - Notification of `toolchange` in unregistration algorithm.

This PR does not introduce the "*" or "native-agent" keywords that we've proposed, to control a tool's exposure to the built-in agent. That will also be considered in a follow-up.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/pull/179.html" title="Last updated on May 19, 2026, 8:53 PM UTC (42dcc53)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/179/986f461...42dcc53.html" title="Last updated on May 19, 2026, 8:53 PM UTC (42dcc53)">Diff</a>