### PR TITLE
Gate registerTool on document.domain being disabled

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -332,6 +332,9 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 1. If |tool owner| is not [=Document/fully active=], then [=exception/throw=] an
    "{{InvalidStateError}}" {{DOMException}}.
 
+1. If [=this=]'s [=relevant global object=]'s {{Window/originAgentCluster}} is false, then
+  [=exception/throw=] a "{{SecurityError}}" {{DOMException}}.
+
 1. If |tool owner| is not [=allowed to use=] the "{{tools}}" feature, then [=exception/throw=] a
    "{{NotAllowedError}}" {{DOMException}}.
 

--- a/index.bs
+++ b/index.bs
@@ -92,11 +92,16 @@ spec:html; type:dfn;
   text:form-associated element
   text:browsing context group set
   text:unique internal value
+  text:is origin-keyed
 </pre>
 <pre class="anchors">
 spec: SECURE-CONTEXTS; urlPrefix: https://w3c.github.io/webappsec-secure-contexts/
   type: abstract-op
     text: is origin potentially trustworthy?; url: is-origin-trustworthy
+spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
+  type: dfn
+    text: surrounding agent; url: surrounding-agent
+    text: agent cluster; url: sec-agent-clusters
 </pre>
 
 <h2 id="intro">Introduction</h2>
@@ -332,8 +337,10 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 1. If |tool owner| is not [=Document/fully active=], then [=exception/throw=] an
    "{{InvalidStateError}}" {{DOMException}}.
 
-1. If [=this=]'s [=relevant global object=]'s {{Window/originAgentCluster}} is false, then
-  [=exception/throw=] a "{{SecurityError}}" {{DOMException}}.
+1. If this's [=surrounding agent=]'s [=agent cluster=]'s [=is origin-keyed=] is false
+   and this's [=relevant settings object=]'s [=environment settings object/origin=]'s
+   [=origin/scheme=] is not <code>"file"</code>, then [=exception/throw=] a "{{SecurityError}}"
+   {{DOMException}}.
 
 1. If |tool owner| is not [=allowed to use=] the "{{tools}}" feature, then [=exception/throw=] a
    "{{NotAllowedError}}" {{DOMException}}.


### PR DESCRIPTION
Following https://chromium-review.googlesource.com/c/chromium/src/+/7896184, this change updates the spec to gate `registerTool()` on `document.domain` being disabled.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/webmcp/pull/197.html" title="Last updated on Jun 5, 2026, 3:27 PM UTC (9065910)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/197/bc9c77a...beaufortfrancois:9065910.html" title="Last updated on Jun 5, 2026, 3:27 PM UTC (9065910)">Diff</a>