### PR TITLE
Add a section for private browsing to S&P considerations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1083,6 +1083,13 @@ This creates a personalization-to-fingerprinting pipeline where sites can extrac
   TODO: Document risks and implications of [=agents=] carrying state from one origin to another. Detail how tools executed on one origin may carry state from another origin, potentially leading to data leakage or same-origin policy bypasses if not handled securely by the [=user agent=]. This section should probably talk about the WebMCP permissions policy and other cross-origin opt in mechanisms. 
 </p>
 
+<h4 id="interaction-with-private-browsing">Interaction with Private Browsing Modes</h4>
+
+Many user agents provide ephemeral, short-lived, "Private" or "Incognito" browsing modes that are disconnected from a user's primary profile, in that they do not share the same history or web-accessible storage.
+Users generally expect this boundary between regular and private browsing to be maintained and protected by the user agent. Exposing [=agents=] to private browsing activity (e.g. by giving them access to WebMCP
+tools in private browsing) may inadvertently leak information across this boundary and lead to unauthorized joining or retention of private browsing data. Users agents are responsible for ensuring that their
+respective private browsing modes are safely exposed to [=agents=] and that these agents have the ability to responsibly handle private browsing information.
+
 <h3 id="mitigations">Mitigations</h3>
 
 <h4 id="mitigation-restrict-input-lengths">Restricting maximum input lengths</h4>

--- a/index.bs
+++ b/index.bs
@@ -1085,8 +1085,8 @@ This creates a personalization-to-fingerprinting pipeline where sites can extrac
 
 <h4 id="interaction-with-private-browsing">Interaction with Private Browsing Modes</h4>
 
-Many user agents provide ephemeral, short-lived, "Private" or "Incognito" browsing modes that are disconnected from a user's primary profile, in that they do not share the same history or web-accessible storage.
-Users generally expect this boundary between regular and private browsing to be maintained and protected by the user agent. Exposing [=agents=] to private browsing activity (e.g. by giving them access to WebMCP
+Many user agents provide ephemeral, short-lived, [private browsing modes](https://w3ctag.github.io/private-browsing-modes/) that are disconnected from a user's primary profile, in that they do not share the same history or web-accessible storage.
+Users generally expect this boundary between regular and private browsing to be maintained and protected by the user agent. Exposing [=agents=] to private browsing activity (e.g., by giving them access to WebMCP
 tools in private browsing) may inadvertently leak information across this boundary and lead to unauthorized joining or retention of private browsing data. Users agents are responsible for ensuring that their
 respective private browsing modes are safely exposed to [=agents=] and that these agents have the ability to responsibly handle private browsing information.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/johannhof/webmcp/pull/201.html" title="Last updated on Jun 8, 2026, 5:24 PM UTC (a8435d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/201/4733c27...johannhof:a8435d9.html" title="Last updated on Jun 8, 2026, 5:24 PM UTC (a8435d9)">Diff</a>