### PR TITLE
Reject registerTool() promise when signal is aborted

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -399,9 +399,8 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 
 1. If |signal| [=map/exists=], then:
 
-   1. If |signal| is [=AbortSignal/aborted=], then optionally [=report a warning to the console=]
-      indicating that the tool was not registered because the {{AbortSignal}} was already
-      [=AbortSignal/aborted=], and return.
+   1. If |signal| is [=AbortSignal/aborted=], then return [=a promise rejected with=]
+      |signal|'s [=AbortSignal/abort reason=].
 
    1. [=AbortSignal/add|Add an abort algorithm=] to |signal| that [=model context/unregisters a
       tool=] given [=this=] and |tool name|.

--- a/index.bs
+++ b/index.bs
@@ -395,6 +395,8 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 1. Let |untrusted content hint| be true if |tool|'s {{ModelContextTool/annotations}} [=map/exists=] and
    its {{ToolAnnotations/untrustedContentHint}} is true. Otherwise, let it be false.
 
+1. Let |promise| be [=a new promise=] created in [=this=]'s [=relevant realm=].
+
 1. Let |signal| be |options|'s {{ModelContextRegisterToolOptions/signal}}.
 
 1. If |signal| [=map/exists=], then:
@@ -402,8 +404,11 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
    1. If |signal| is [=AbortSignal/aborted=], then return [=a promise rejected with=]
       |signal|'s [=AbortSignal/abort reason=].
 
-   1. [=AbortSignal/add|Add an abort algorithm=] to |signal| that [=model context/unregisters a
-      tool=] given [=this=] and |tool name|.
+   1. [=AbortSignal/add|Add the following abort steps=] to |signal|:
+
+        1. [=model context/Unregister a tool=] given [=this=] and |tool name|.
+
+        1. [=Reject=] |promise| with |signal|'s [=AbortSignal/abort reason=].
 
 1. Let |exposed origins| be an empty [=list=] of [=origins=].
 
@@ -446,8 +451,6 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
    :: |exposed origins|
 
 1. Set [=this=]'s [=ModelContext/internal context=][|tool name|] to |tool definition|.
-
-1. Let |promise| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 
 1. Run the following steps [=in parallel=]:
 

--- a/index.bs
+++ b/index.bs
@@ -258,7 +258,7 @@ To <dfn for="model context">unregister a tool</dfn> given a {{ModelContext}} |mo
 1. Let |tool map| be |modelContext|'s [=ModelContext/internal context=]'s [=model context/tool
    map=].
 
-1. [=Assert=] |tool map|[|tool name|] [=map/exists=].
+1. If |tool map|[|tool name|] does not [=map/exist=], then return.
 
 1. Let |exposed origins| be |tool map|[|tool name|]'s [=tool definition/exposed origins=].
 


### PR DESCRIPTION
I believe we should reject `registerTool()` promise when signal is aborted instead now following https://github.com/webmachinelearning/webmcp/pull/200/ changes

It's part of changes required for webmachinelearning/webmcp#175.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/webmcp/pull/202.html" title="Last updated on Jun 17, 2026, 8:30 AM UTC (7526883)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/202/7addecf...beaufortfrancois:7526883.html" title="Last updated on Jun 17, 2026, 8:30 AM UTC (7526883)">Diff</a>