### PR TITLE
Remove `ModelContextClient` for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ As the WebMCP proposal continues to evolve with community and stakeholder feedba
 
 - **Output schema**: Supporting structured `outputSchema` contracts (complementing `inputSchema`) to help LLMs reliably reason about the return values of tools. See [Issue #9](https://github.com/webmachinelearning/webmcp/issues/9).
 
-- **User prompting and elicitation**: Exploring a way for a tool to prompt the user for confirmation when tools require explicit user authorization. This could be done by delegating to the agent and its harness, or by invoking native browser permission dialogue outside of the agent loop. See [Issue #165](https://github.com/webmachinelearning/webmcp/issues/165) and [Issue #50](https://github.com/webmachinelearning/webmcp/issues/50) for discussion about the [`ModelContextClient`](https://webmachinelearning.github.io/webmcp/#modelcontextclient) interface.
+- **User prompting and elicitation**: Exploring a way for a tool to prompt the user for confirmation when tools require explicit user authorization. This could be done by delegating to the agent and its harness, or by invoking native browser permission dialogue outside of the agent loop. See [Issue #165](https://github.com/webmachinelearning/webmcp/issues/165) and [Issue #50](https://github.com/webmachinelearning/webmcp/issues/50) for discussion about the `ModelContextClient` interface.
 
 - **Tool progress reporting**: For long-running tasks (e.g., batch processing or generating content), the agent may want a way to track a tool's progress. We are exploring how this intersects with the established [MCP Progress](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress) specification.
 

--- a/index.bs
+++ b/index.bs
@@ -482,7 +482,7 @@ dictionary ToolAnnotations {
   boolean untrustedContentHint = false;
 };
 
-callback ToolExecuteCallback = Promise<any> (object input, ModelContextClient client);
+callback ToolExecuteCallback = Promise<any> (object input);
 </xmp>
 
 <dl class="domintro">
@@ -510,7 +510,7 @@ callback ToolExecuteCallback = Promise<any> (object input, ModelContextClient cl
 
   <dt><code><var ignore>tool</var>["{{ModelContextTool/execute}}"]</code></dt>
   <dd>
-    <p>A callback function that is invoked when an [=agent=] calls the tool. The function receives the input parameters and a {{ModelContextClient}} object.
+    <p>A callback function that is invoked when an [=agent=] calls the tool. The function receives the input parameters.
 
     <p>The function can be asynchronous and return a promise, in which case the [=agent=] will receive the result once the promise is resolved.
   </dd>
@@ -558,35 +558,6 @@ dictionary ModelContextRegisterToolOptions {
   </dd>
 </dl>
 
-
-<h4 id="model-context-client">ModelContextClient Interface</h4>
-
-The {{ModelContextClient}} interface represents an [=agent=] executing a tool provided by the site through the {{ModelContext}} API.
-
-<xmp class="idl">
-[Exposed=Window, SecureContext]
-interface ModelContextClient {
-  Promise<any> requestUserInteraction(UserInteractionCallback callback);
-};
-
-callback UserInteractionCallback = Promise<any> ();
-</xmp>
-
-<dl class="domintro">
-  <dt><code><var ignore>client</var>.{{ModelContextClient/requestUserInteraction(callback)}}</code></dt>
-  <dd>
-    <p>Asynchronously requests user input during the execution of a tool.
-
-    <p>The callback function is invoked to perform the user interaction (e.g., showing a confirmation dialog), and the promise resolves with the result of the callback.
-  </dd>
-</dl>
-
-<div algorithm>
-The <dfn method for=ModelContextClient>requestUserInteraction(<var ignore>callback</var>)</dfn> method steps are:
-
-1. TODO: fill this out.
-
-</div>
 
 <h3 id="declarative-api">Declarative WebMCP</h3>
 


### PR DESCRIPTION
This PR removes `ModelContextClient` until https://github.com/webmachinelearning/webmcp/issues/165 and https://github.com/webmachinelearning/webmcp/pull/204 settle on a more permanent design for this flow. We do this because this interface and its only method are not fully specified and not implemented yet.

/cc @beaufortfrancois


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/pull/205.html" title="Last updated on Jun 11, 2026, 3:30 PM UTC (07781f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/205/b8617aa...07781f0.html" title="Last updated on Jun 11, 2026, 3:30 PM UTC (07781f0)">Diff</a>