### PR TITLE
Move `annotations` into a separate object, in preparation for `getTools()`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -445,7 +445,8 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
    :: steps that invoke |tool|'s {{ModelContextTool/execute}}
 
    : [=tool definition/annotations=]
-   :: null if |tool|'s {{ModelContextTool/annotations}} does not [=map/exist=]. Otherwise, an [=annotations=] with the following [=struct/items=]:
+   :: null if |tool|'s {{ModelContextTool/annotations}} does not [=map/exist=]. Otherwise, an
+      [=annotations=] with the following [=struct/items=]:
 
       : [=annotations/read-only hint=]
       :: |tool|'s {{ModelContextTool/annotations}}'s {{ToolAnnotations/readOnlyHint}}

--- a/index.bs
+++ b/index.bs
@@ -172,15 +172,23 @@ A <dfn>tool definition</dfn> is a [=struct=] with the following [=struct/items=]
      "internal" steps that have not been defined yet, that describe how to fill out a <{form}> and
      its [=form-associated elements=].
 
+  : <dfn>annotations</dfn>
+  :: an [=annotations=]-or-null.
+
+  : <dfn>exposed origins</dfn>
+  :: a [=list=] or [=origins=], initially [=list/empty=].
+</dl>
+
+An <dfn>annotations</dfn> is a [=struct=] with the following [=struct/items=]:
+
+<dl dfn-for="annotations">
   : <dfn>read-only hint</dfn>
   :: a [=boolean=], initially false.
 
   : <dfn>untrusted content hint</dfn>
   :: a [=boolean=], initially false.
-
-  : <dfn>exposed origins</dfn>
-  :: a [=list=] or [=origins=], initially [=list/empty=].
 </dl>
+
 
 <hr>
 
@@ -390,12 +398,6 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
      </ol>
    </div>
 
-1. Let |read-only hint| be true if |tool|'s {{ModelContextTool/annotations}} [=map/exists=] and
-   its {{ToolAnnotations/readOnlyHint}} is true. Otherwise, let it be false.
-
-1. Let |untrusted content hint| be true if |tool|'s {{ModelContextTool/annotations}} [=map/exists=] and
-   its {{ToolAnnotations/untrustedContentHint}} is true. Otherwise, let it be false.
-
 1. Let |promise| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 
 1. Let |signal| be |options|'s {{ModelContextRegisterToolOptions/signal}}.
@@ -442,11 +444,14 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
    : [=tool definition/execute steps=]
    :: steps that invoke |tool|'s {{ModelContextTool/execute}}
 
-   : [=tool definition/read-only hint=]
-   :: |read-only hint|
+   : [=tool definition/annotations=]
+   :: null if |tool|'s {{ModelContextTool/annotations}} does not [=map/exist=]. Otherwise, an [=annotations=] with the following [=struct/items=]:
 
-   : [=tool definition/untrusted content hint=]
-   :: |untrusted content hint|
+      : [=annotations/read-only hint=]
+      :: |tool|'s {{ModelContextTool/annotations}}'s {{ToolAnnotations/readOnlyHint}}
+
+      : [=annotations/untrusted content hint=]
+      :: |tool|'s {{ModelContextTool/annotations}}'s {{ToolAnnotations/untrustedContentHint}}
 
    : [=tool definition/exposed origins=]
    :: |exposed origins|


### PR DESCRIPTION
This is pre-work for https://github.com/webmachinelearning/webmcp/pull/223#discussion_r3620114038. When this lands and https://github.com/webmachinelearning/webmcp/pull/223 is rebased on top of it, it'll be easier to make `RegisteredTool` expose an filled-out annotations object only when it was provided at registration time, and `undefined` otherwise.

CC @beaufortfrancois.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/pull/225.html" title="Last updated on Jul 21, 2026, 3:26 PM UTC (16e587a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/225/1aece7c...16e587a.html" title="Last updated on Jul 21, 2026, 3:26 PM UTC (16e587a)">Diff</a>