### PR TITLE
Spec the `executeTool()` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ By default, WebMCP is enabled in top-level `Window`s and its same-origin iframes
 
 Calls to `document.modelContext.registerTool()` will return a promise rejected with `NotAllowedError` DOMException when the permission is disabled, whether by the `allow` attribute or the `Permissions-Policy: tools=()` header. Handling of declarative tool registration errors, including when the permission is disabled is TBD; see [Issue #182](https://github.com/webmachinelearning/webmcp/issues/182).
 
-#### Cross-origin iframe exposure: `exposedTo`
+#### Cross-origin iframe exposure: `registerTool() and `exposedTo`
 
 By default, tools registered by a document are only exposed to itself, same-origin documents in the same tree, and built-in browser agents (see this <a href=#built-in-agent-default-exposure>discussion</a>). To support author-provided agents running in frames, developers can selectively share tools with secure origins of their choice, `exposedTo` option during registration:
 
@@ -342,9 +342,76 @@ Any document in the tree matching these origins (and allowed to use `tools` perm
 - Receive the `toolchange` event on its `document.modelContext` when the tool is registered or unregistered.
 - Be able to discover and run the tools
 
-#### Discovering and running tools
+#### Discovering and running tools: `getTools()` and `executeTool()`
 
-TODO: Spec and describe the `modelContext.getTools()` and `modelContext.executeTool()` APIs.
+Once tools are registered, in-page agents can discover and invoke them using `getTools()` and `executeTool()`.
+
+Calling `document.modelContext.getTools()` returns a promise that resolves with an array of `RegisteredTool` dictionary objects. Each object contains the tool's `name`, `description`, `inputSchema`, `origin`, and owner `window`:
+
+```js
+// Discover tools exposed by same-origin frames in the tree (default)
+const tools = await document.modelContext.getTools();
+
+for (const tool of tools) {
+  console.log(`Tool: ${tool.name} (from ${tool.origin})`);
+  console.log(`Description: ${tool.description}`);
+  console.log(`Parameters schema:`, tool.inputSchema);
+}
+
+// Or discover tools exposed by specific cross-origin partner frames:
+const crossOriginTools = await document.modelContext.getTools({
+  fromOrigins: ["https://trusted-partner.example"]
+});
+```
+
+An agent executes a discovered `RegisteredTool` by passing the tool dictionary and input arguments along to `document.modelContext.executeTool()`. The browser securely mediates the execution, ensuring the [`exposedTo`](https://webmachinelearning.github.io/webmcp/#dom-modelcontextregistertooloptions-exposedto) and [`fromOrigins`](https://webmachinelearning.github.io/webmcp/#dom-modelcontextgettooloptions-fromorigins) agree, and the tool runs in the tool owner's execution context:
+
+```js
+const tools = await document.modelContext.getTools();
+const addTodoTool = tools.find(t => t.name === "add-todo");
+
+if (addTodoTool) {
+  try {
+    const result = await document.modelContext.executeTool(
+      addTodoTool,
+      { text: "Buy groceries" }
+    );
+    console.log("Tool result:", result);
+  } catch (error) {
+    console.error("Tool execution failed:", error);
+  }
+}
+```
+
+##### Cancelling execution with `AbortSignal`
+
+Tool invocations can be cancelled mid-execution (e.g., if the user aborts an ongoing request, as they might with the "stop button" that's present in most agent UIs) by passing an `AbortSignal`:
+
+```js
+const controller = new AbortController();
+
+const executionPromise = document.modelContext.executeTool(
+  addTodoTool,
+  { text: "Buy groceries" },
+  { signal: controller.signal }
+);
+
+// If the user cancels the interaction:
+stopButton.addEventListener('click', e => controller.abort());
+```
+
+The tool's [execution callback](https://webmachinelearning.github.io/webmcp/#callbackdef-toolexecutecallback) receives this signal via its [`options.signal`](https://webmachinelearning.github.io/webmcp/#dom-modelcontextexecutetooloptions-signal) parameter, allowing it to abort underlying network requests or asynchronous tasks cleanly.
+
+##### Responding to dynamic tool updates: the `toolchange` event
+
+When tools are added, removed, or updated dynamically (such as when user interactions result in new tools being registered), `document.modelContext` fires a `toolchange` event:
+
+```js
+document.modelContext.addEventListener("toolchange", async () => {
+  const currentTools = await document.modelContext.getTools();
+  updateAgentToolRegistry(currentTools);
+});
+```
 
 
 ## Alternatives Considered

--- a/index.bs
+++ b/index.bs
@@ -193,6 +193,76 @@ An <dfn>annotations</dfn> is a [=struct=] with the following [=struct/items=]:
   :: a [=boolean=], initially false.
 </dl>
 
+<h3 id="pending-tool-executions">Pending tool executions</h3>
+
+A <dfn>pending tool execution</dfn> is a [=struct=] with the following [=struct/items=]:
+
+<dl dfn-for="pending tool execution">
+  : <dfn>caller document</dfn>
+  :: a {{Document}}.
+
+  : <dfn>target document</dfn>
+  :: a {{Document}}.
+
+  : <dfn>tool name</dfn>
+  :: a [=string=].
+
+  : <dfn>completion steps</dfn>
+  :: an algorithm that takes a [=string=]-or-null and a [=boolean=].
+</dl>
+
+A [=traversable navigable=] has a <dfn for="traversable navigable">pending tool executions
+map</dfn>, which is a [=map=] whose keys are [=unique internal values=] and whose values are
+[=pending tool execution=] [=structs=]. It is initially empty.
+
+Note: This map is only ever mutated from steps [=in parallel=]. This simulates the single,
+authoritative "browser process" that most modern browsers implement, where execution tracking sits
+outside any individual Document process's event loop, and is accessed asynchronously via some
+inter-process communication mechanism.
+
+<hr>
+
+<div algorithm=unloading-document-cleanup-steps>
+This specification's [=unloading document cleanup steps=], given a {{Document}} |document|, are as
+follows:
+
+1. Let |traversable| be |document|'s [=node navigable=]'s [=navigable/traversable navigable=].
+
+1. Run the following steps [=in parallel=]:
+
+   1. Let |executionsToRemove| be an empty [=list=].
+
+   1. [=map/For each=] |uuid| &rarr; |execution| of |traversable|'s [=traversable navigable/pending
+      tool executions map=]:
+
+      1. If |document| is |execution|'s [=pending tool execution/target document=] or |document| is
+         |execution|'s [=pending tool execution/caller document=], then [=list/append=] |uuid| to
+         |executionsToRemove|.
+
+   1. [=list/For each=] |uuid| of |executionsToRemove|:
+
+      1. Let |execution| be |traversable|'s [=traversable navigable/pending tool executions
+         map=][|uuid|].
+
+      1. <p id=caller-destroyed-cleanup>If |document| is |execution|'s [=pending tool
+         execution/target document=], then run |execution|'s [=pending tool execution/completion
+         steps=] given null and false.</p>
+
+         Note: This removes |execution| from the [=traversable navigable/pending tool executions
+         map=].
+
+      1. If |document| is |execution|'s [=pending tool execution/caller document=], then:
+
+         1. [=map/Remove=] |traversable|'s [=traversable navigable/pending tool executions
+            map=][|uuid|].
+
+         1. Issue(#48): Abort the `AbortSignal` in |execution|'s [=pending tool execution/target
+            document=], so the tool can abort early now that the caller is dead.
+
+      1. [=Assert=]: |traversable|'s [=traversable navigable/pending tool executions map=][|uuid|]
+         does not [=map/exist=].
+
+</div>
 
 <hr>
 
@@ -288,7 +358,7 @@ a [=string=] |inputArguments|, and an algorithm |completionSteps|, are as follow
     when <a href=https://github.com/webmachinelearning/webmcp/issues/92>issue #92</a> is
     resolved.</p>
 
-    <div class=example id=unregistration-race>
+    <div class=example id=unregistration-execution-race>
      <xmp class=language-js>
      // -- Tool owner document. --
      const oldInputSchema = {...};
@@ -371,10 +441,33 @@ To <dfn for="model context">unregister a tool</dfn> given a {{ModelContext}} |mo
 
 1. [=map/Remove=] |tool map|[|tool name|].
 
+1. Let |targetDocument| be |modelContext|'s [=relevant global object=]'s [=associated
+   Document|associated <code>Document</code>=].
+
+1. Let |traversable| be |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=].
+
 1. Run the following steps [=in parallel=]:
 
-   1. [=Notify documents of a tool change=] given |modelContext|'s [=relevant global object=]'s
-      [=associated Document|associated <code>Document</code>=] and |exposed origins|.
+   1. Let |canceledExecutions| be an empty [=list=].
+
+   1. [=map/For each=] |uuid| &rarr; |execution| of |traversable|'s [=traversable navigable/pending
+      tool executions map=]:
+
+      1. If |execution|'s [=pending tool execution/target document=] is |targetDocument| and
+         |execution|'s [=pending tool execution/tool name=] is |tool name|, then [=list/append=]
+         |uuid| to |canceledExecutions|.
+
+   1. [=list/For each=] |uuid| of |canceledExecutions|:
+
+      1. Let |execution| be |traversable|'s [=traversable navigable/pending tool executions
+         map=][|uuid|].
+
+      1. Run |execution|'s [=pending tool execution/completion steps=] given null and false.
+
+         Note: This removes |execution| from the [=traversable navigable/pending tool executions
+         map=].
+
+   1. [=Notify documents of a tool change=] given |targetDocument| and |exposed origins|.
 
 </div>
 
@@ -789,13 +882,66 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 
       Issue: Support more granular errors than "{{UnknownError}}", based on each failure case.
 
+   1. Let |uuid| be a new [=unique internal value=].
+
    1. Let |completionSteps| be an algorithm that takes a [=string=]-or-null |result| and a [=boolean=] |success|, and runs the following steps:
 
       1. [=Assert=]: these steps are running [=in parallel=].
 
+      1. If |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=]'s [=traversable navigable/pending tool executions map=][|uuid|] does not [=map/exist=], then return.
+
+         <div class=note>
+          <p>It is possible that a pending execution identified by |uuid| no longer exists. This can
+          happen due to a race between (a) tool cancellation when the caller document <a
+          href=#caller-destroyed-cleanup>gets destroyed</a>; and (b) tool promise resolution. Both
+          of these race to invoke |completionSteps|, and the first invocation will remove the
+          pending execution by its key |uuid|, this check protects subsequent racing invocations.</p>
+
+          <p>This can also happen due to a limitation with tool unregistration. Consider this
+          example:</p>
+
+          <div class=example id=unregistration-race>
+           <xmp class=language-js>
+            const ac = new AbortController();
+            document.modelContext.registerTool({
+              name: "tool"
+              description: "a racy tool",
+              execute: async () => {
+                return new Promise(resolve => {
+                  resolve("tool result");
+                  ac.abort();
+                });
+              }
+            }, {signal: ac.signal});
+           </xmp>
+
+           <p>In this case, tool unregistration happens after a tool Promise is resolved, but before
+           its fulfillment handler runs. Since both run |completionSteps|, this check protects the
+           second invocation from trying to remove the same pending execution twice.</p>
+          </div>
+         </div>
+
+      1. [=map/Remove=] |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=]'s [=traversable navigable/pending tool executions map=][|uuid|].
+
       1. If |success| is true, then [=queue a global task=] on the [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to [=resolve=] |promise| with |result|.
 
       1. Otherwise, [=queue a global task=] on the [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}.
+
+   1. Let |execution| be a new [=pending tool execution=], with the following [=struct/items=]:
+
+      : [=pending tool execution/caller document=]
+      :: |invokingDocument|
+
+      : [=pending tool execution/target document=]
+      :: |targetDocument|
+
+      : [=pending tool execution/tool name=]
+      :: |toolName|
+
+      : [=pending tool execution/completion steps=]
+      :: |completionSteps|
+
+   1. Set |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=]'s [=traversable navigable/pending tool executions map=][|uuid|] to |execution|.
 
    1. [=Queue a global task=] on the [=webmcp task source=] given |targetWindow| to run the [=tool execute steps=] given |toolName|, |targetDocument|, |inputArguments|, and |completionSteps|.
 
@@ -1028,9 +1174,10 @@ The <dfn>synthesize a declarative JSON Schema object algorithm</dfn>, given a <{
 </pre>
 
 <div algorithm>
-The <dfn>declarative execute steps</dfn> are as follows.
+The <dfn>declarative execute steps</dfn> are as follows:
 
-domfarolino
+Issue: Spec the declarative execution steps, and their integration with form elements.
+
 </div>
 
 <h3 id="events">Events</h3>

--- a/index.bs
+++ b/index.bs
@@ -417,7 +417,7 @@ The {{ModelContext}} interface provides methods for web applications to register
 interface ModelContext : EventTarget {
   Promise<undefined> registerTool(ModelContextTool tool, optional ModelContextRegisterToolOptions options = {});
   Promise<sequence<RegisteredTool>> getTools(optional ModelContextGetToolOptions options = {});
-  Promise<DOMString?> executeTool(RegisteredTool tool, DOMString inputArguments, optional ExecuteToolOptions options = {});
+  Promise<DOMString?> executeTool(RegisteredTool tool, DOMString inputArguments, optional ModelContextExecuteToolOptions options = {});
 
   attribute EventHandler ontoolchange;
 };
@@ -701,7 +701,7 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 1. If |invokingDocument| is not [=Document/fully active=], then return [=a promise rejected with=]
    an "{{InvalidStateError}}" {{DOMException}}.
 
-1. If this's [=surrounding agent=]'s [=agent cluster=]'s [=is origin-keyed=] is false and this's
+1. If [=this=]'s [=surrounding agent=]'s [=agent cluster=]'s [=is origin-keyed=] is false and [=this=]'s
    [=relevant settings object=]'s [=environment settings object/origin=]'s [=origin/scheme=] is not
    "<code>file</code>", then return [=a promise rejected with=] a "{{SecurityError}}"
    {{DOMException}}.
@@ -721,9 +721,9 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 
 1. Let |promise| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 
-1. Let |signal| be |options|'s {{ExecuteToolOptions/signal}} if it [=map/exists=]; otherwise null.
+1. If |options|'s {{ModelContextExecuteToolOptions/signal}} [=map/exists=], then:
 
-1. If |signal| is not null, then:
+   1. Let |signal| be |options|'s {{ModelContextExecuteToolOptions/signal}}.
 
    1. If |signal| is [=AbortSignal/aborted=], then return [=a promise rejected with=] |signal|'s
       [=AbortSignal/abort reason=].
@@ -911,19 +911,18 @@ dictionary ModelContextGetToolOptions {
      same-origin documents.
 </dl>
 
-<h4 id="execute-tool-options">ExecuteToolOptions Dictionary</h4>
+<h4 id="model-context-execute-tool-options">ModelContextExecuteToolOptions Dictionary</h4>
 
-The {{ExecuteToolOptions}} dictionary allows web applications to pass options to
-{{ModelContext/executeTool()}}.
+The {{ModelContextExecuteToolOptions}} dictionary allows web applications to pass options to {{ModelContext/executeTool()}}.
 
 <xmp class="idl">
-dictionary ExecuteToolOptions {
+dictionary ModelContextExecuteToolOptions {
   AbortSignal signal;
 };
 </xmp>
 
 <dl class="domintro">
-  : <code><var ignore>options</var>["{{ExecuteToolOptions/signal}}"]</code>
+  : <code><var ignore>options</var>["{{ModelContextExecuteToolOptions/signal}}"]</code>
   :: An {{AbortSignal}} that can be used to cancel the execution of the tool.
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -349,7 +349,7 @@ The <dfn>tool execute steps</dfn>, given a [=string=] |toolName|, a {{Document}}
    and abort these steps.
 
    Issue: Support the plumbing of more granular errors back to the invoker; this should result in a
-   "{{NotFoundError}}" in the invoking document.
+   "{{NotFoundError}}" in the calling document.
 
    <div class=note>
     <p>This protects us against a race between tool unregistration and execution. While tool
@@ -803,10 +803,10 @@ The <dfn method for=ModelContext>getTools(<var>options</var>)</dfn> method steps
 The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArguments</var>,
 <var>options</var>)</dfn> method steps are:
 
-1. Let |invokingDocument| be [=this=]'s [=relevant global object=]'s [=associated
+1. Let |callerDocument| be [=this=]'s [=relevant global object=]'s [=associated
    Document|associated <code>Document</code>=].
 
-1. If |invokingDocument| is not [=Document/fully active=], then return [=a promise rejected with=]
+1. If |callerDocument| is not [=Document/fully active=], then return [=a promise rejected with=]
    an "{{InvalidStateError}}" {{DOMException}}.
 
 1. If [=this=]'s [=surrounding agent=]'s [=agent cluster=]'s [=is origin-keyed=] is false and
@@ -814,7 +814,7 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
    [=origin/scheme=] is not "<code>file</code>", then return [=a promise rejected with=] a
    "{{SecurityError}}" {{DOMException}}.
 
-1. If |invokingDocument| is not [=allowed to use=] the "{{tools}}" feature, then return [=a promise
+1. If |callerDocument| is not [=allowed to use=] the "{{tools}}" feature, then return [=a promise
    rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
 
 1. Let |expectedTargetOriginURL| be the result of [=URL parser|parsing=] |tool|'s
@@ -854,8 +854,8 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 1. Run the following steps [=in parallel=]:
 
    1. If |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=] is not
-      |invokingDocument|'s [=node navigable=]'s [=navigable/traversable navigable=], then [=queue a
-      global task=] on the [=webmcp task source=] given |invokingDocument|'s [=relevant global
+      |callerDocument|'s [=node navigable=]'s [=navigable/traversable navigable=], then [=queue a
+      global task=] on the [=webmcp task source=] given |callerDocument|'s [=relevant global
       object=] to [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these
       steps.
 
@@ -866,10 +866,10 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 
    1. Let |targetOrigin| be |targetDocument|'s [=Document/origin=].
 
-   1. Let |callerOrigin| be |invokingDocument|'s [=Document/origin=].
+   1. Let |callerOrigin| be |callerDocument|'s [=Document/origin=].
 
    1. If |targetOrigin| is not [=same origin=] with |expectedTargetOrigin|, then [=queue a global
-      task=] on the [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to
+      task=] on the [=webmcp task source=] given |callerDocument|'s [=relevant global object=] to
       [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these steps.
 
       Issue: Support more granular errors than "{{UnknownError}}", based on each failure case.
@@ -880,7 +880,7 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
    1. Let |toolName| be |tool|'s {{RegisteredTool/name}}.
 
    1. If |targetToolMap|[|toolName|] does not [=map/exist=], then [=queue a global task=] on the
-      [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to [=reject=]
+      [=webmcp task source=] given |callerDocument|'s [=relevant global object=] to [=reject=]
       |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these steps.
 
       Issue: Support more granular errors than "{{UnknownError}}", based on each failure case.
@@ -889,7 +889,7 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 
    1. If [=tool is exposed to an origin=] given |targetOrigin|, |tool definition|'s [=tool
       definition/exposed origins=], and |callerOrigin| returns false, then [=queue a global task=]
-      on the [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to
+      on the [=webmcp task source=] given |callerDocument|'s [=relevant global object=] to
       [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these steps.
 
       Issue: Support more granular errors than "{{UnknownError}}", based on each failure case.
@@ -941,16 +941,16 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
          navigable=]'s [=traversable navigable/pending tool executions map=][|uuid|].
 
       1. If |success| is true, then [=queue a global task=] on the [=webmcp task source=] given
-         |invokingDocument|'s [=relevant global object=] to [=resolve=] |promise| with |result|.
+         |callerDocument|'s [=relevant global object=] to [=resolve=] |promise| with |result|.
 
-      1. Otherwise, [=queue a global task=] on the [=webmcp task source=] given |invokingDocument|'s
+      1. Otherwise, [=queue a global task=] on the [=webmcp task source=] given |callerDocument|'s
          [=relevant global object=] to [=reject=] |promise| with an "{{UnknownError}}"
          {{DOMException}}.
 
    1. Let |execution| be a new [=pending tool execution=], with the following [=struct/items=]:
 
       : [=pending tool execution/caller document=]
-      :: |invokingDocument|
+      :: |callerDocument|
 
       : [=pending tool execution/target document=]
       :: |targetDocument|

--- a/index.bs
+++ b/index.bs
@@ -96,6 +96,9 @@ spec:html; type:dfn;
   text:is origin-keyed
 </pre>
 <pre class="anchors">
+spec: html; urlPrefix: https://html.spec.whatwg.org/C
+  type: dfn
+    text: browsing context group
 spec: SECURE-CONTEXTS; urlPrefix: https://w3c.github.io/webappsec-secure-contexts/
   type: abstract-op
     text: is origin potentially trustworthy?; url: is-origin-trustworthy
@@ -742,6 +745,9 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
       object=] to [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these
       steps.
 
+      Issue(#227): Consider supporting tool execution across top-level documents in the same
+      [=browsing context group=].
+
    1. Let |targetOrigin| be |targetDocument|'s [=Document/origin=].
 
    1. Let |callerOrigin| be |invokingDocument|'s [=Document/origin=].
@@ -781,6 +787,11 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
       1. Otherwise, [=queue a global task=] on the [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}.
 
    1. [=Queue a global task=] on the [=webmcp task source=] given |targetWindow| to run the [=tool execute steps=] given |toolName|, |targetDocument|, |inputArguments|, and |completionSteps|.
+
+      Note: Because documents only process tasks on their event loops when [=Document/fully
+      active=], if |targetDocument| is not [=Document/fully active=], this will simply queue the
+      steps to execute the tool, to run when the document finally becomes active again (i.e., when
+      it leaves the bf-cache).
 
 1. Return |promise|.
 

--- a/index.bs
+++ b/index.bs
@@ -446,8 +446,7 @@ is a [=model context=] [=struct=] created alongside the {{ModelContext}}.
 
   <dt><code><var ignore>document</var>.{{Document/modelContext}}.{{ModelContext/executeTool(tool, inputArguments, options)}}</code></dt>
   <dd>
-    <p>Executes a tool on the document it was registered on. Returns a promise that resolves to the
-    result of the tool's execution.</p>
+    <p>Executes a tool on the document it was registered on. Returns a promise that resolves to the stringified result of the tool's execution.</p>
   </dd>
 </dl>
 
@@ -712,8 +711,9 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 1. Let |expectedTargetOriginURL| be the result of [=URL parser|parsing=] |tool|'s
    {{RegisteredTool/origin}}.
 
-1. If |expectedTargetOriginURL| is failure, then return [=a promise rejected with=] a
-   "{{DataError}}" {{DOMException}}.
+1. If |expectedTargetOriginURL| is failure, or |expectedTargetOriginURL|'s [=url/origin=] is an
+   [=opaque origin=], then return [=a promise rejected with=] a "{{NotSupportedError}}"
+   {{DOMException}}.
 
 1. Let |expectedTargetOrigin| be |expectedTargetOriginURL|'s [=url/origin=].
 
@@ -750,6 +750,8 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
       Issue(#227): Consider supporting tool execution across top-level documents in the same
       [=browsing context group=].
 
+      Issue: Support more granular errors than "{{UnknownError}}", based on each failure case.
+
    1. Let |targetOrigin| be |targetDocument|'s [=Document/origin=].
 
    1. Let |callerOrigin| be |invokingDocument|'s [=Document/origin=].
@@ -774,9 +776,9 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
    1. Let |tool definition| be |targetToolMap|[|toolName|].
 
    1. If [=tool is exposed to an origin=] given |targetOrigin|, |tool definition|'s [=tool
-      definition/exposed origins=], and |callerOrigin| is false, then [=queue a global task=] on the
-      [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to [=reject=]
-      |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these steps.
+      definition/exposed origins=], and |callerOrigin| returns false, then [=queue a global task=]
+      on the [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to
+      [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these steps.
 
       Issue: Support more granular errors than "{{UnknownError}}", based on each failure case.
 

--- a/index.bs
+++ b/index.bs
@@ -257,15 +257,73 @@ a [=list=] of [=origins=] |exposed origins|, and an [=origin=] |accessing origin
 </div>
 
 <div algorithm>
-The <dfn>imperative execute steps</dfn>, given a {{ModelContextTool}} |tool|, a {{Window}}
-|targetWindow|, a [=string=] |inputArguments|, and an algorithm |completionSteps|, are as follows:
+The <dfn>tool execute steps</dfn>, given a [=string=] |toolName|, a {{Document}} |targetDocument|,
+a [=string=] |inputArguments|, and an algorithm |completionSteps|, are as follows. The
+|completionSteps| algorithm takes a [=string=]-or-null <var ignore>result</var> and a [=boolean=] <var ignore>success</var>.
 
-1. [=Assert=]: these steps are running on |targetWindow|'s [=relevant agent=]'s [=agent/event
+1. [=Assert=]: these steps are running on |targetDocument|'s [=relevant agent=]'s [=agent/event loop=].
+
+1. Let |toolMap| be |targetDocument|'s [=Document/associated ModelContext|associated
+   <code>ModelContext</code>=]'s [=ModelContext/internal context=]'s [=model context/tool map=].
+
+1. If |toolMap|[|toolName|] does not [=map/exist=], then run |completionSteps| given null and false,
+   and abort these steps.
+
+   Issue: Support the plumbing of more granular errors back to the invoker; this should result in a
+   "{{NotFoundError}}" in the invoking document.
+
+   <div class=note>
+    <p>This protects us against a race between tool unregistration and execution. While tool
+    <em>existence</em> is protected from this race, tool unregistration followed by a quick
+    re-registration of a tool with the same |toolName| but input schema is <em>not</em>
+    protected against.</p>
+
+    <p>This might result in |inputArguments| for an old tool being applied to the
+    [=tool definition/input schema=] of a newer tool, and causing whatever error that might cause,
+    when <a href=https://github.com/webmachinelearning/webmcp/issues/92>issue #92</a> is
+    resolved.</p>
+
+    <div class=example id=unregistration-race>
+     <xmp class=language-js>
+     // -- Tool owner document. --
+     const oldInputSchema = {...};
+     const newInputSchema = {...};
+     const ac = new AbortController();
+     document.modelContext.registerTool({..., inputSchema: oldInputSchema}, {signal: ac.signal});
+
+     // Unregister, and quickly re-register with an updated input schema.
+     ac.abort();
+     document.modelContext.registerTool({..., inputSchema: newInputSchema});
+
+
+     // -- Executing document. --
+     //
+     // This could target either the "old" tool, or the "new" one above,
+     // and the execution might encounter any requisite errors due to the mismatch.
+     const [tool] = await document.modelContext.getTools();
+     document.modelContext.executeTool(tool, "{a: 10}");
+     </xmp>
+    </div>
+   </div>
+
+1. Let |tool| be |toolMap|[|toolName|].
+
+1. Run |tool|'s [=tool definition/execute steps=] given |inputArguments| and |completionSteps|.
+
+   Note: This is the point where we branch into either the [=imperative execute steps=] or the [=declarative execute steps=].
+
+</div>
+
+<div algorithm>
+The <dfn>imperative execute steps</dfn>, given a {{ModelContextTool}} |tool|, a {{Document}} |targetDocument|, a [=string=] |inputArguments|, and an algorithm |completionSteps|, are as follows:
+
+1. [=Assert=]: these steps are running on |targetDocument|'s [=relevant agent=]'s [=agent/event
    loop=].
 
 1. Let |inputObject| be the result of [=parse a JSON string to a JavaScript value=] given
-   |inputArguments| and |targetWindow|'s [=relevant realm=]. If <a spec=webidl lt="an exception was thrown">exception was thrown</a>, then
-   run |completionSteps| given null and false, and abort these steps.
+   |inputArguments| and |targetDocument|'s [=relevant realm=]. If <a spec=webidl lt="an exception
+   was thrown">exception was thrown</a>, then run |completionSteps| given null and false, and abort
+   these steps.
 
    Issue: Support more granular errors; here we should return something that prompts the caller to reject its {{Promise}} with a "{{DataError}}" {{DOMException}}.
 
@@ -489,8 +547,7 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
    :: |stringified input schema|
 
    : [=tool definition/execute steps=]
-   :: An algorithm that take a [=string=] |inputArguments| and an algorithm |completionSteps|. These steps run the [=imperative execute steps=]
-      given |tool|, [=this=]'s [=relevant global object=], |inputArguments|, and |completionSteps|.
+   :: An algorithm that take a [=string=] |inputArguments| and an algorithm |completionSteps| and runs the [=imperative execute steps=] given |tool|, |tool owner|, |inputArguments|, and |completionSteps|.
 
    : [=tool definition/annotations=]
    :: null if |tool|'s {{ModelContextTool/annotations}} does not [=map/exist=]. Otherwise, an
@@ -723,8 +780,7 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 
       1. Otherwise, [=queue a global task=] on the [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}.
 
-   1. [=Queue a global task=] on the [=webmcp task source=] given |targetWindow| to run |tool
-      definition|'s [=tool definition/execute steps=] given |inputArguments| and |completionSteps|.
+   1. [=Queue a global task=] on the [=webmcp task source=] given |targetWindow| to run the [=tool execute steps=] given |toolName|, |targetDocument|, |inputArguments|, and |completionSteps|.
 
 1. Return |promise|.
 
@@ -949,6 +1005,12 @@ The <dfn>synthesize a declarative JSON Schema object algorithm</dfn>, given a <{
   }
 }
 </pre>
+
+<div algorithm>
+The <dfn>declarative execute steps</dfn> are as follows.
+
+domfarolino
+</div>
 
 <h3 id="events">Events</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -94,6 +94,8 @@ spec:html; type:dfn;
   text:browsing context group set
   text:unique internal value
   text:is origin-keyed
+spec: webidl; type: dfn;
+  text: an exception was thrown
 </pre>
 <pre class="anchors">
 spec: html; urlPrefix: https://html.spec.whatwg.org/C
@@ -324,7 +326,7 @@ The <dfn>imperative execute steps</dfn>, given a {{ModelContextTool}} |tool|, a 
    loop=].
 
 1. Let |inputObject| be the result of [=parse a JSON string to a JavaScript value=] given
-   |inputArguments| and |targetDocument|'s [=relevant realm=]. If <a spec=webidl lt="an exception
+   |inputArguments| and |targetDocument|'s [=relevant realm=]. If <a lt="an exception
    was thrown">exception was thrown</a>, then run |completionSteps| given null and false, and abort
    these steps.
 

--- a/index.bs
+++ b/index.bs
@@ -685,9 +685,6 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
       object=] to [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these
       steps.
 
-      Issue: TODO(domfarolino): File an issue about cross-frame-tree, same-browsing-context-group
-      tool execution.
-
    1. Let |targetOrigin| be |targetDocument|'s [=Document/origin=].
 
    1. Let |callerOrigin| be |invokingDocument|'s [=Document/origin=].

--- a/index.bs
+++ b/index.bs
@@ -343,11 +343,15 @@ The <dfn>imperative execute steps</dfn>, given a {{ModelContextTool}} |tool|, a 
 
    - If |toolPromise| was fulfilled with value |v|:
 
-      1. Let |serializedResult| be the result of [=serializing a JavaScript value to a JSON string=] given |v|. If this throws an exception, run |completionSteps| given null and false, and abort these steps.
+       1. Let |serializedResult| be the result of [=serializing a JavaScript value to a JSON string=] given |v|. If this throws an exception, run |completionSteps| given null and false, and abort these steps.
 
-      1. Run |completionSteps| given |serializedResult| and true.
+       1. Run |completionSteps| given |serializedResult| and true.
 
-   - If |toolPromise| was rejected with reason <var ignore>r</var>, then run |completionSteps| given null and false.
+   - If |toolPromise| was rejected with reason |r|, then:
+
+       1. Optionally [=report a warning to the console=] describing |r|.
+
+       1. Run |completionSteps| given null and false.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -844,7 +844,7 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
       Issue(#48): Wire up |signal| to the tool execution callback in the tool host's document, so
       that tool abort is communicated all the way through. This should also fire the
       "<code>toolcanceled</code>" event in the target document. See also <a
-      href=https://github.com/webmachinelearning/webmcp/issues/146>issue #146</a>.
+      href=https://github.com/webmachinelearning/webmcp/pull/146>pull request #146</a>.
 
 1. Let |targetWindow| be |tool|'s {{RegisteredTool/window}}.
 

--- a/index.bs
+++ b/index.bs
@@ -421,7 +421,7 @@ The {{ModelContext}} interface provides methods for web applications to register
 interface ModelContext : EventTarget {
   Promise<undefined> registerTool(ModelContextTool tool, optional ModelContextRegisterToolOptions options = {});
   Promise<sequence<RegisteredTool>> getTools(optional ModelContextGetToolOptions options = {});
-  Promise<DOMString?> executeTool(RegisteredTool tool, DOMString inputArguments, optional ModelContextExecuteToolOptions options = {});
+  Promise<DOMString> executeTool(RegisteredTool tool, DOMString inputArguments, optional ModelContextExecuteToolOptions options = {});
 
   attribute EventHandler ontoolchange;
 };

--- a/index.bs
+++ b/index.bs
@@ -736,7 +736,10 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 
       1. [=Reject=] |promise| with |signal|'s [=AbortSignal/abort reason=].
 
-      Issue(#48): Wire up |signal| to the tool execution callback in the tool host's document, so that tool abort is communicated all the way through.
+      Issue(#48): Wire up |signal| to the tool execution callback in the tool host's document, so
+      that tool abort is communicated all the way through. This should also fire the
+      "<code>toolcanceled</code>" event in the target document. See also <a
+      href=https://github.com/webmachinelearning/webmcp/issues/146>issue #146</a>.
 
 1. Let |targetWindow| be |tool|'s {{RegisteredTool/window}}.
 

--- a/index.bs
+++ b/index.bs
@@ -169,9 +169,11 @@ A <dfn>tool definition</dfn> is a [=struct=] with the following [=struct/items=]
      [[!JSON-SCHEMA]]
 
   : <dfn>execute steps</dfn>
-  :: an algorithm that takes both a [=string=] and an algorithm <var ignore>completionSteps</var> that itself takes a [=string=]-or-null and a [=boolean=].
+  :: an algorithm that takes both a [=string=] and an algorithm <var ignore>completionSteps</var>
+     that itself takes a [=string=]-or-null and a [=boolean=].
 
-     Note: For tools registered imperatively, these steps will simply invoke the [=imperative execute steps=]. For tools registered
+     Note: For tools registered imperatively, these steps will simply invoke the [=imperative
+     execute steps=]. For tools registered
      [declaratively](https://github.com/webmachinelearning/webmcp/pull/76), this will be a set of
      "internal" steps that have not been defined yet, that describe how to fill out a <{form}> and
      its [=form-associated elements=].
@@ -332,11 +334,13 @@ a [=list=] of [=origins=] |exposed origins|, and an [=origin=] |accessing origin
 </div>
 
 <div algorithm>
-The <dfn>tool execute steps</dfn>, given a [=string=] |toolName|, a {{Document}} |targetDocument|,
-a [=string=] |inputArguments|, and an algorithm |completionSteps|, are as follows. The
-|completionSteps| algorithm takes a [=string=]-or-null <var ignore>result</var> and a [=boolean=] <var ignore>success</var>.
+The <dfn>tool execute steps</dfn>, given a [=string=] |toolName|, a {{Document}} |targetDocument|, a
+[=string=] |inputArguments|, and an algorithm |completionSteps|, are as follows. The
+|completionSteps| algorithm takes a [=string=]-or-null <var ignore>result</var> and a [=boolean=]
+<var ignore>success</var>.
 
-1. [=Assert=]: these steps are running on |targetDocument|'s [=relevant agent=]'s [=agent/event loop=].
+1. [=Assert=]: these steps are running on |targetDocument|'s [=relevant agent=]'s [=agent/event
+   loop=].
 
 1. Let |toolMap| be |targetDocument|'s [=Document/associated ModelContext|associated
    <code>ModelContext</code>=]'s [=ModelContext/internal context=]'s [=model context/tool map=].
@@ -350,13 +354,12 @@ a [=string=] |inputArguments|, and an algorithm |completionSteps|, are as follow
    <div class=note>
     <p>This protects us against a race between tool unregistration and execution. While tool
     <em>existence</em> is protected from this race, tool unregistration followed by a quick
-    re-registration of a tool with the same |toolName| but input schema is <em>not</em>
-    protected against.</p>
+    re-registration of a tool with the same |toolName| but input schema is <em>not</em> protected
+    against.</p>
 
-    <p>This might result in |inputArguments| for an old tool being applied to the
-    [=tool definition/input schema=] of a newer tool, and causing whatever error that might cause,
-    when <a href=https://github.com/webmachinelearning/webmcp/issues/92>issue #92</a> is
-    resolved.</p>
+    <p>This might result in |inputArguments| for an old tool being applied to the [=tool
+    definition/input schema=] of a newer tool, and causing whatever error that might cause, when <a
+    href=https://github.com/webmachinelearning/webmcp/issues/92>issue #92</a> is resolved.</p>
 
     <div class=example id=unregistration-execution-race>
      <xmp class=language-js>
@@ -385,24 +388,28 @@ a [=string=] |inputArguments|, and an algorithm |completionSteps|, are as follow
 
 1. Run |tool|'s [=tool definition/execute steps=] given |inputArguments| and |completionSteps|.
 
-   Note: This is the point where we branch into either the [=imperative execute steps=] or the [=declarative execute steps=].
+   Note: This is the point where we branch into either the [=imperative execute steps=] or the
+   [=declarative execute steps=].
 
 </div>
 
 <div algorithm>
-The <dfn>imperative execute steps</dfn>, given a {{ModelContextTool}} |tool|, a {{Document}} |targetDocument|, a [=string=] |inputArguments|, and an algorithm |completionSteps|, are as follows:
+The <dfn>imperative execute steps</dfn>, given a {{ModelContextTool}} |tool|, a {{Document}}
+|targetDocument|, a [=string=] |inputArguments|, and an algorithm |completionSteps|, are as follows:
 
 1. [=Assert=]: these steps are running on |targetDocument|'s [=relevant agent=]'s [=agent/event
    loop=].
 
 1. Let |inputObject| be the result of [=parse a JSON string to a JavaScript value=] given
-   |inputArguments| and |targetDocument|'s [=relevant realm=]. If <a lt="an exception
-   was thrown">exception was thrown</a>, then run |completionSteps| given null and false, and abort
+   |inputArguments| and |targetDocument|'s [=relevant realm=]. If <a lt="an exception was
+   thrown">exception was thrown</a>, then run |completionSteps| given null and false, and abort
    these steps.
 
-   Issue: Support more granular errors; here we should return something that prompts the caller to reject its {{Promise}} with a "{{DataError}}" {{DOMException}}.
+   Issue: Support more granular errors; here we should return something that prompts the caller to
+   reject its {{Promise}} with a "{{DataError}}" {{DOMException}}.
 
-1. If |inputObject| [=Object type|is not an Object=] is false, then run |completionSteps| given null and false, and abort these steps.
+1. If |inputObject| [=Object type|is not an Object=] is false, then run |completionSteps| given null
+   and false, and abort these steps.
 
    Issue(#146): Specify and fire the "<code>toolactivated</code>" event.
 
@@ -413,7 +420,9 @@ The <dfn>imperative execute steps</dfn>, given a {{ModelContextTool}} |tool|, a 
 
    - If |toolPromise| was fulfilled with value |v|:
 
-       1. Let |serializedResult| be the result of [=serializing a JavaScript value to a JSON string=] given |v|. If this throws an exception, run |completionSteps| given null and false, and abort these steps.
+       1. Let |serializedResult| be the result of [=serializing a JavaScript value to a JSON
+          string=] given |v|. If this throws an exception, run |completionSteps| given null and
+          false, and abort these steps.
 
        1. Run |completionSteps| given |serializedResult| and true.
 
@@ -543,7 +552,8 @@ is a [=model context=] [=struct=] created alongside the {{ModelContext}}.
 
   <dt><code><var ignore>document</var>.{{Document/modelContext}}.{{ModelContext/executeTool(tool, inputArguments, options)}}</code></dt>
   <dd>
-    <p>Executes a tool on the document it was registered on. Returns a promise that resolves to the stringified result of the tool's execution.</p>
+    <p>Executes a tool on the document it was registered on. Returns a promise that resolves to the
+    stringified result of the tool's execution.</p>
   </dd>
 </dl>
 
@@ -648,7 +658,9 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
    :: |stringified input schema|
 
    : [=tool definition/execute steps=]
-   :: An algorithm that take a [=string=] |inputArguments| and an algorithm |completionSteps| and runs the [=imperative execute steps=] given |tool|, |tool owner|, |inputArguments|, and |completionSteps|.
+   :: An algorithm that take a [=string=] |inputArguments| and an algorithm |completionSteps| and
+      runs the [=imperative execute steps=] given |tool|, |tool owner|, |inputArguments|, and
+      |completionSteps|.
 
    : [=tool definition/annotations=]
    :: null if |tool|'s {{ModelContextTool/annotations}} does not [=map/exist=]. Otherwise, an
@@ -797,10 +809,10 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 1. If |invokingDocument| is not [=Document/fully active=], then return [=a promise rejected with=]
    an "{{InvalidStateError}}" {{DOMException}}.
 
-1. If [=this=]'s [=surrounding agent=]'s [=agent cluster=]'s [=is origin-keyed=] is false and [=this=]'s
-   [=relevant settings object=]'s [=environment settings object/origin=]'s [=origin/scheme=] is not
-   "<code>file</code>", then return [=a promise rejected with=] a "{{SecurityError}}"
-   {{DOMException}}.
+1. If [=this=]'s [=surrounding agent=]'s [=agent cluster=]'s [=is origin-keyed=] is false and
+   [=this=]'s [=relevant settings object=]'s [=environment settings object/origin=]'s
+   [=origin/scheme=] is not "<code>file</code>", then return [=a promise rejected with=] a
+   "{{SecurityError}}" {{DOMException}}.
 
 1. If |invokingDocument| is not [=allowed to use=] the "{{tools}}" feature, then return [=a promise
    rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
@@ -884,18 +896,22 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
 
    1. Let |uuid| be a new [=unique internal value=].
 
-   1. Let |completionSteps| be an algorithm that takes a [=string=]-or-null |result| and a [=boolean=] |success|, and runs the following steps:
+   1. Let |completionSteps| be an algorithm that takes a [=string=]-or-null |result| and a
+      [=boolean=] |success|, and runs the following steps:
 
       1. [=Assert=]: these steps are running [=in parallel=].
 
-      1. If |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=]'s [=traversable navigable/pending tool executions map=][|uuid|] does not [=map/exist=], then return.
+      1. If |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=]'s
+         [=traversable navigable/pending tool executions map=][|uuid|] does not [=map/exist=], then
+         return.
 
          <div class=note>
           <p>It is possible that a pending execution identified by |uuid| no longer exists. This can
           happen due to a race between (a) tool cancellation when the caller document <a
           href=#caller-destroyed-cleanup>gets destroyed</a>; and (b) tool promise resolution. Both
           of these race to invoke |completionSteps|, and the first invocation will remove the
-          pending execution by its key |uuid|, this check protects subsequent racing invocations.</p>
+          pending execution by its key |uuid|, this check protects subsequent racing
+          invocations.</p>
 
           <p>This can also happen due to a limitation with tool unregistration. Consider this
           example:</p>
@@ -921,11 +937,15 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
           </div>
          </div>
 
-      1. [=map/Remove=] |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=]'s [=traversable navigable/pending tool executions map=][|uuid|].
+      1. [=map/Remove=] |targetDocument|'s [=node navigable=]'s [=navigable/traversable
+         navigable=]'s [=traversable navigable/pending tool executions map=][|uuid|].
 
-      1. If |success| is true, then [=queue a global task=] on the [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to [=resolve=] |promise| with |result|.
+      1. If |success| is true, then [=queue a global task=] on the [=webmcp task source=] given
+         |invokingDocument|'s [=relevant global object=] to [=resolve=] |promise| with |result|.
 
-      1. Otherwise, [=queue a global task=] on the [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}.
+      1. Otherwise, [=queue a global task=] on the [=webmcp task source=] given |invokingDocument|'s
+         [=relevant global object=] to [=reject=] |promise| with an "{{UnknownError}}"
+         {{DOMException}}.
 
    1. Let |execution| be a new [=pending tool execution=], with the following [=struct/items=]:
 
@@ -941,9 +961,11 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArgument
       : [=pending tool execution/completion steps=]
       :: |completionSteps|
 
-   1. Set |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=]'s [=traversable navigable/pending tool executions map=][|uuid|] to |execution|.
+   1. Set |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=]'s
+      [=traversable navigable/pending tool executions map=][|uuid|] to |execution|.
 
-   1. [=Queue a global task=] on the [=webmcp task source=] given |targetWindow| to run the [=tool execute steps=] given |toolName|, |targetDocument|, |inputArguments|, and |completionSteps|.
+   1. [=Queue a global task=] on the [=webmcp task source=] given |targetWindow| to run the [=tool
+      execute steps=] given |toolName|, |targetDocument|, |inputArguments|, and |completionSteps|.
 
       Note: Because documents only process tasks on their event loops when [=Document/fully
       active=], if |targetDocument| is not [=Document/fully active=], this will simply queue the
@@ -1068,7 +1090,8 @@ dictionary ModelContextGetToolOptions {
 
 <h4 id="model-context-execute-tool-options">ModelContextExecuteToolOptions Dictionary</h4>
 
-The {{ModelContextExecuteToolOptions}} dictionary allows web applications to pass options to {{ModelContext/executeTool()}}.
+The {{ModelContextExecuteToolOptions}} dictionary allows web applications to pass options to
+{{ModelContext/executeTool()}}.
 
 <xmp class="idl">
 dictionary ModelContextExecuteToolOptions {

--- a/index.bs
+++ b/index.bs
@@ -164,10 +164,9 @@ A <dfn>tool definition</dfn> is a [=struct=] with the following [=struct/items=]
      [[!JSON-SCHEMA]]
 
   : <dfn>execute steps</dfn>
-  :: a set of steps to invoke the tool.
+  :: an algorithm that takes both a [=string=] and an algorithm <var ignore>completionSteps</var> that itself takes a [=string=]-or-null and a [=boolean=].
 
-     Note: For tools registered imperatively, these steps will simply invoke the supplied
-     {{ToolExecuteCallback}} callback. For tools registered
+     Note: For tools registered imperatively, these steps will simply invoke the [=imperative execute steps=]. For tools registered
      [declaratively](https://github.com/webmachinelearning/webmcp/pull/76), this will be a set of
      "internal" steps that have not been defined yet, that describe how to fill out a <{form}> and
      its [=form-associated elements=].
@@ -258,6 +257,38 @@ a [=list=] of [=origins=] |exposed origins|, and an [=origin=] |accessing origin
 </div>
 
 <div algorithm>
+The <dfn>imperative execute steps</dfn>, given a {{ModelContextTool}} |tool|, a {{Window}}
+|targetWindow|, a [=string=] |inputArguments|, and an algorithm |completionSteps|, are as follows:
+
+1. [=Assert=]: these steps are running on |targetWindow|'s [=relevant agent=]'s [=agent/event
+   loop=].
+
+1. Let |inputObject| be the result of [=parse a JSON string to a JavaScript value=] given
+   |inputArguments| and |targetWindow|'s [=relevant realm=]. If <a spec=webidl lt="an exception was thrown">exception was thrown</a>, then
+   run |completionSteps| given null and false, and abort these steps.
+
+   Issue: Support more granular errors; here we should return something that prompts the caller to reject its {{Promise}} with a "{{DataError}}" {{DOMException}}.
+
+1. If |inputObject| [=Object type|is not an Object=] is false, then run |completionSteps| given null and false, and abort these steps.
+
+   Issue(#146): Specify and fire the "<code>toolactivated</code>" event.
+
+1. Let |toolPromise| be the result of [=invoke|invoking=] |tool|'s {{ModelContextTool/execute}} with
+   |inputObject|.
+
+1. [=promise/React=] to |toolPromise|:
+
+   - If |toolPromise| was fulfilled with value |v|:
+
+      1. Let |serializedResult| be the result of [=serializing a JavaScript value to a JSON string=] given |v|. If this throws an exception, run |completionSteps| given null and false, and abort these steps.
+
+      1. Run |completionSteps| given |serializedResult| and true.
+
+   - If |toolPromise| was rejected with reason <var ignore>r</var>, then run |completionSteps| given null and false.
+
+</div>
+
+<div algorithm>
 To <dfn for="model context">unregister a tool</dfn> given a {{ModelContext}} |modelContext| and a
 [=string=] |tool name|, run these steps:
 
@@ -323,6 +354,7 @@ The {{ModelContext}} interface provides methods for web applications to register
 interface ModelContext : EventTarget {
   Promise<undefined> registerTool(ModelContextTool tool, optional ModelContextRegisterToolOptions options = {});
   Promise<sequence<RegisteredTool>> getTools(optional ModelContextGetToolOptions options = {});
+  Promise<DOMString?> executeTool(RegisteredTool tool, DOMString inputArguments, optional ExecuteToolOptions options = {});
 
   attribute EventHandler ontoolchange;
 };
@@ -347,6 +379,12 @@ is a [=model context=] [=struct=] created alongside the {{ModelContext}}.
     descendants that are exposed to this document. This API is designed for so-called "in-page"
     agents written in JavaScript, and possibly living in <{iframe}>s. The [=user agent=]'s [=browser
     agent=] uses a different internal mechanism to retrieve the tools exposed to it.</p>
+  </dd>
+
+  <dt><code><var ignore>document</var>.{{Document/modelContext}}.{{ModelContext/executeTool(tool, inputArguments, options)}}</code></dt>
+  <dd>
+    <p>Executes a tool on the document it was registered on. Returns a promise that resolves to the
+    result of the tool's execution.</p>
   </dd>
 </dl>
 
@@ -451,7 +489,8 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
    :: |stringified input schema|
 
    : [=tool definition/execute steps=]
-   :: steps that invoke |tool|'s {{ModelContextTool/execute}}
+   :: An algorithm that take a [=string=] |inputArguments| and an algorithm |completionSteps|. These steps run the [=imperative execute steps=]
+      given |tool|, [=this=]'s [=relevant global object=], |inputArguments|, and |completionSteps|.
 
    : [=tool definition/annotations=]
    :: null if |tool|'s {{ModelContextTool/annotations}} does not [=map/exist=]. Otherwise, an
@@ -472,8 +511,8 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 
   1. [=Notify documents of a tool change=] given |tool owner| and |exposed origins|.
 
-  1. [=Queue a global task=] on the [=webmcp task source=] given |global| to
-     [=resolve=] |promise| with undefined.
+  1. [=Queue a global task=] on the [=webmcp task source=] given |global| to [=resolve=] |promise|
+     with undefined.
 
 1. Return |promise|
 
@@ -590,6 +629,110 @@ The <dfn method for=ModelContext>getTools(<var>options</var>)</dfn> method steps
 
 </div>
 
+<div algorithm>
+The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputArguments</var>,
+<var>options</var>)</dfn> method steps are:
+
+1. Let |invokingDocument| be [=this=]'s [=relevant global object=]'s [=associated
+   Document|associated <code>Document</code>=].
+
+1. If |invokingDocument| is not [=Document/fully active=], then return [=a promise rejected with=]
+   an "{{InvalidStateError}}" {{DOMException}}.
+
+1. If this's [=surrounding agent=]'s [=agent cluster=]'s [=is origin-keyed=] is false and this's
+   [=relevant settings object=]'s [=environment settings object/origin=]'s [=origin/scheme=] is not
+   "<code>file</code>", then return [=a promise rejected with=] a "{{SecurityError}}"
+   {{DOMException}}.
+
+1. If |invokingDocument| is not [=allowed to use=] the "{{tools}}" feature, then return [=a promise
+   rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
+
+1. Let |expectedTargetOriginURL| be the result of [=URL parser|parsing=] |tool|'s
+   {{RegisteredTool/origin}}.
+
+1. If |expectedTargetOriginURL| is failure, then return [=a promise rejected with=] a
+   "{{DataError}}" {{DOMException}}.
+
+1. Let |expectedTargetOrigin| be |expectedTargetOriginURL|'s [=url/origin=].
+
+1. [=Assert=]: |expectedTargetOrigin| is not an [=opaque origin=].
+
+1. Let |promise| be [=a new promise=] created in [=this=]'s [=relevant realm=].
+
+1. Let |signal| be |options|'s {{ExecuteToolOptions/signal}} if it [=map/exists=]; otherwise null.
+
+1. If |signal| is not null, then:
+
+   1. If |signal| is [=AbortSignal/aborted=], then return [=a promise rejected with=] |signal|'s
+      [=AbortSignal/abort reason=].
+
+   1. [=AbortSignal/add|Add the following abort steps=] to |signal|:
+
+      1. [=Reject=] |promise| with |signal|'s [=AbortSignal/abort reason=].
+
+      Issue(#48): Wire up |signal| to the tool execution callback in the tool host's document, so that tool abort is communicated all the way through.
+
+1. Let |targetWindow| be |tool|'s {{RegisteredTool/window}}.
+
+1. Let |targetDocument| be |targetWindow|'s [=associated Document|associated
+   <code>Document</code>=].
+
+1. Run the following steps [=in parallel=]:
+
+   1. If |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=] is not
+      |invokingDocument|'s [=node navigable=]'s [=navigable/traversable navigable=], then [=queue a
+      global task=] on the [=webmcp task source=] given |invokingDocument|'s [=relevant global
+      object=] to [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these
+      steps.
+
+      Issue: TODO(domfarolino): File an issue about cross-frame-tree, same-browsing-context-group
+      tool execution.
+
+   1. Let |targetOrigin| be |targetDocument|'s [=Document/origin=].
+
+   1. Let |callerOrigin| be |invokingDocument|'s [=Document/origin=].
+
+   1. If |targetOrigin| is not [=same origin=] with |expectedTargetOrigin|, then [=queue a global
+      task=] on the [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to
+      [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these steps.
+
+      Issue: Support more granular errors than "{{UnknownError}}", based on each failure case.
+
+   1. Let |targetToolMap| be |targetDocument|'s [=Document/associated ModelContext|associated
+      <code>ModelContext</code>=]'s [=ModelContext/internal context=]'s [=model context/tool map=].
+
+   1. Let |toolName| be |tool|'s {{RegisteredTool/name}}.
+
+   1. If |targetToolMap|[|toolName|] does not [=map/exist=], then [=queue a global task=] on the
+      [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to [=reject=]
+      |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these steps.
+
+      Issue: Support more granular errors than "{{UnknownError}}", based on each failure case.
+
+   1. Let |tool definition| be |targetToolMap|[|toolName|].
+
+   1. If [=tool is exposed to an origin=] given |targetOrigin|, |tool definition|'s [=tool
+      definition/exposed origins=], and |callerOrigin| is false, then [=queue a global task=] on the
+      [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to [=reject=]
+      |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these steps.
+
+      Issue: Support more granular errors than "{{UnknownError}}", based on each failure case.
+
+   1. Let |completionSteps| be an algorithm that takes a [=string=]-or-null |result| and a [=boolean=] |success|, and runs the following steps:
+
+      1. [=Assert=]: these steps are running [=in parallel=].
+
+      1. If |success| is true, then [=queue a global task=] on the [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to [=resolve=] |promise| with |result|.
+
+      1. Otherwise, [=queue a global task=] on the [=webmcp task source=] given |invokingDocument|'s [=relevant global object=] to [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}.
+
+   1. [=Queue a global task=] on the [=webmcp task source=] given |targetWindow| to run |tool
+      definition|'s [=tool definition/execute steps=] given |inputArguments| and |completionSteps|.
+
+1. Return |promise|.
+
+</div>
+
 <h4 id="model-context-tool">ModelContextTool Dictionary</h4>
 
 The {{ModelContextTool}} dictionary describes a tool that can be invoked by [=agents=].
@@ -617,19 +760,21 @@ callback ToolExecuteCallback = Promise<any> (object input);
 <dl class="domintro">
   <dt><code><var ignore>tool</var>["{{ModelContextTool/name}}"]</code></dt>
   <dd>
-    <p>A unique identifier for the tool. This is used by [=agents=] to reference the tool when making tool calls.
+    <p>A unique identifier for the tool. This is used by [=agents=] to reference the tool when
+    making tool calls.
   </dd>
 
   <dt><code><var ignore>tool</var>["{{ModelContextTool/title}}"]</code></dt>
   <dd>
-    <p>A label for the tool. This is used by the user agent to reference the tool in the user interface.
-    <p>It is recommended that this string be localized to the user's
-{{NavigatorLanguage/language}}.
+    <p>A label for the tool. This is used by the user agent to reference the tool in the user
+    interface. <p>It is recommended that this string be localized to the user's
+    {{NavigatorLanguage/language}}.
   </dd>
 
   <dt><code><var ignore>tool</var>["{{ModelContextTool/description}}"]</code></dt>
   <dd>
-    <p>A natural language description of the tool's functionality. This helps [=agents=] understand when and how to use the tool.
+    <p>A natural language description of the tool's functionality. This helps [=agents=] understand
+    when and how to use the tool.
   </dd>
 
   <dt><code><var ignore>tool</var>["{{ModelContextTool/inputSchema}}"]</code></dt>
@@ -698,6 +843,22 @@ dictionary ModelContextGetToolOptions {
   :: An array of origins from which to query tools. Documents whose origin appears in this list, or
      are same-origin with the caller, have their tools queried. An empty list only includes
      same-origin documents.
+</dl>
+
+<h4 id="execute-tool-options">ExecuteToolOptions Dictionary</h4>
+
+The {{ExecuteToolOptions}} dictionary allows web applications to pass options to
+{{ModelContext/executeTool()}}.
+
+<xmp class="idl">
+dictionary ExecuteToolOptions {
+  AbortSignal signal;
+};
+</xmp>
+
+<dl class="domintro">
+  : <code><var ignore>options</var>["{{ExecuteToolOptions/signal}}"]</code>
+  :: An {{AbortSignal}} that can be used to cancel the execution of the tool.
 </dl>
 
 <h4 id="registered-tool">RegisteredTool Dictionary</h4>


### PR DESCRIPTION
This PR specifies the `executeTool()` API on `ModelContext`.

Closes https://github.com/webmachinelearning/webmcp/issues/51.
Closes https://github.com/webmachinelearning/webmcp/issues/57.
Closes https://github.com/webmachinelearning/webmcp/issues/117.
Closes https://github.com/webmachinelearning/webmcp/issues/159.
Closes https://github.com/webmachinelearning/webmcp/issues/160.

This PR also introduces the `AbortSignal` member to `ModelContextExecuteToolOptions`, but it is not wired up to actually abort the tool owner's callback yet. That will be handled in a follow-up PR towards fixing #48.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/pull/226.html" title="Last updated on Aug 14, 2026, 3:06 PM UTC (ee98c1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/226/5801678...ee98c1b.html" title="Last updated on Aug 14, 2026, 3:06 PM UTC (ee98c1b)">Diff</a>