### PR TITLE
Add implementation-status.md to track browser implementation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ WebMCP lets developers expose web application functionality—either JavaScript 
 
 TypeScript type definitions for WebMCP are available in the [`webmcp-types`](https://www.npmjs.com/package/webmcp-types) npm package.
 
+See [Implementation Status](implementation-status.md) for browser support.
 
 ## Background and Motivation
 

--- a/implementation-status.md
+++ b/implementation-status.md
@@ -2,7 +2,7 @@
 
 This document shows the implementation status of WebMCP across different browsers.
 
-<a href="#brave"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/brave/brave_128x128.png" alt="Brave logo"></a> <a href="#chrome"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_128x128.png" alt="Chrome logo"></a> <a href="#firefox"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_128x128.png" alt="Firefox logo"></a> <a href="#safari"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_128x128.png" alt="Safari logo"></a>
+<a href="#brave"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/brave/brave_128x128.png" alt="Brave logo"></a> <a href="#chrome"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_128x128.png" alt="Chrome logo"></a> <a href="#edge"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_128x128.png" alt="Edge logo"></a> <a href="#firefox"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_128x128.png" alt="Firefox logo"></a> <a href="#safari"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_128x128.png" alt="Safari logo"></a>
 
 # Brave
 

--- a/implementation-status.md
+++ b/implementation-status.md
@@ -23,6 +23,7 @@ An [Origin Trial](https://developer.chrome.com/blog/ai-webmcp-origin-trial) is l
 An [Origin Trial](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/0b76fe60-b266-458e-a285-04e375c0c31a) is live in Edge 150.
 
 Refer to Chrome implementation status for platform support.
+
 # Firefox
 
 * [Mozilla standards-positions](https://github.com/mozilla/standards-positions/issues/1412)

--- a/implementation-status.md
+++ b/implementation-status.md
@@ -18,6 +18,11 @@ An [Origin Trial](https://developer.chrome.com/blog/ai-webmcp-origin-trial) is l
 * [Intent to Experiment](https://groups.google.com/a/chromium.org/g/blink-dev/c/gmYffo5WOE8/m/OJxuQRP3AAAJ)
 * [Chrome Status entry](https://chromestatus.com/feature/5117755740913664)
 
+# Edge
+
+An [Origin Trial](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/0b76fe60-b266-458e-a285-04e375c0c31a) is live in Edge 150.
+
+Refer to Chrome implementation status for platform support.
 # Firefox
 
 * [Mozilla standards-positions](https://github.com/mozilla/standards-positions/issues/1412)

--- a/implementation-status.md
+++ b/implementation-status.md
@@ -1,0 +1,28 @@
+# Implementation Status
+
+This document shows the implementation status of WebMCP across different browsers.
+
+<a href="#brave"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/brave/brave_128x128.png" alt="Brave logo"></a> <a href="#chrome"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_128x128.png" alt="Chrome logo"></a> <a href="#firefox"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_128x128.png" alt="Firefox logo"></a> <a href="#safari"><img width=64 src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_128x128.png" alt="Safari logo"></a>
+
+# Brave
+
+Experimental support is added to [Leo AI chat](https://brave.com/leo/).
+
+* [Issue 55232](https://github.com/brave/brave-browser/issues/55232)
+
+# Chrome
+
+An [Origin Trial](https://developer.chrome.com/blog/ai-webmcp-origin-trial) is live in Chrome 149.
+
+* [Early preview program](https://developer.chrome.com/docs/ai/join-epp)
+* [Intent to Experiment](https://groups.google.com/a/chromium.org/g/blink-dev/c/gmYffo5WOE8/m/OJxuQRP3AAAJ)
+* [Chrome Status entry](https://chromestatus.com/feature/5117755740913664)
+
+# Firefox
+
+* [Mozilla standards-positions](https://github.com/mozilla/standards-positions/issues/1412)
+* [Bugzilla entry](https://bugzilla.mozilla.org/show_bug.cgi?id=2018306)
+
+# Safari
+
+* [WebKit standards-positions](https://github.com/WebKit/standards-positions/issues/670)


### PR DESCRIPTION
This PR adds an `implementation-status.md` file to track the implementation status of WebMCP across browser engines (Brave, Chrome, Firefox, Safari).

Following established practices in other W3C Community Groups and Web Standards repositories (such as [Web Bluetooth](https://github.com/WebBluetoothCG/web-bluetooth/blob/main/implementation-status.md) and [WebGPU](https://github.com/gpuweb/gpuweb/wiki/Implementation-Status)), maintaining a dedicated implementation status document provides a central, up-to-date reference for web developers, spec authors, and browser vendors.

This document will be updated periodically as browser support and standards positions evolve.
