### PR TITLE
Validate `exposedTo` before registering `AbortSignal` algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -407,6 +407,20 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
      </ol>
    </div>
 
+1. Let |exposed origins| be an empty [=list=] of [=origins=].
+
+1. If |options|'s {{ModelContextRegisterToolOptions/exposedTo}} [=map/exists=], then:
+
+     1. [=list/For each=] |origin| of |options|'s {{ModelContextRegisterToolOptions/exposedTo}}:
+
+          1. Let |parsedURL| be the result of running the [=URL parser=] on |origin|.
+
+          1. If |parsedURL| is failure or its [=url/origin=] is not [$is origin potentially
+             trustworthy?|potentially trustworthy$], then return [=a promise rejected with=] a
+             "{{SecurityError}}" {{DOMException}}.
+
+          1. [=list/Append=] |parsedURL|'s [=url/origin=] to |exposed origins|.
+
 1. Let |promise| be [=a new promise=] created in [=this=]'s [=relevant realm=].
 
 1. If |options|'s {{ModelContextRegisterToolOptions/signal}} [=map/exists=], then:
@@ -421,20 +435,6 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
         1. [=model context/Unregister a tool=] given [=this=] and |tool name|.
 
         1. [=Reject=] |promise| with |signal|'s [=AbortSignal/abort reason=].
-
-1. Let |exposed origins| be an empty [=list=] of [=origins=].
-
-1. If |options|'s {{ModelContextRegisterToolOptions/exposedTo}} [=map/exists=], then:
-
-     1. [=list/For each=] |origin| of |options|'s {{ModelContextRegisterToolOptions/exposedTo}}:
-
-          1. Let |parsedURL| be the result of running the [=URL parser=] on |origin|.
-
-          1. If |parsedURL| is failure or its [=url/origin=] is not [$is origin potentially
-             trustworthy?|potentially trustworthy$], then return [=a promise rejected with=] a
-             "{{SecurityError}}" {{DOMException}}.
-
-          1. [=list/Append=] |parsedURL|'s [=url/origin=] to |exposed origins|.
 
 1. Let |tool definition| be a new [=tool definition=], with the following [=struct/items=]:
 
@@ -669,17 +669,17 @@ definition itself.
 
 <xmp class="idl">
 dictionary ModelContextRegisterToolOptions {
-  AbortSignal signal;
   sequence<USVString> exposedTo;
+  AbortSignal signal;
 };
 </xmp>
 
 <dl class="domintro">
+  : <code><var ignore>options</var>["{{ModelContextRegisterToolOptions/exposedTo}}"]</code>
+  :: An array of origins that control which documents this tool is exposed to, in the current document's tree.
+
   : <code><var ignore>options</var>["{{ModelContextRegisterToolOptions/signal}}"]</code>
   :: An {{AbortSignal}} that unregisters the tool when aborted.
-
-  : <code><var ignore>options</var>["{{ModelContextRegisterToolOptions/exposedTo}}"]</code>
-  :: <p>An array of origins that control which documents this tool is exposed to, in the current document's tree.
 </dl>
 
 <h4 id="model-context-get-tool-options">ModelContextGetToolOptions Dictionary</h4>

--- a/index.bs
+++ b/index.bs
@@ -407,6 +407,10 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
      </ol>
    </div>
 
+1. If |options|'s {{ModelContextRegisterToolOptions/signal}} [=map/exists=] and is
+   [=AbortSignal/aborted=], then return [=a promise rejected with=] |options|'s
+   {{ModelContextRegisterToolOptions/signal}}'s [=AbortSignal/abort reason=].
+
 1. Let |exposed origins| be an empty [=list=] of [=origins=].
 
 1. If |options|'s {{ModelContextRegisterToolOptions/exposedTo}} [=map/exists=], then:


### PR DESCRIPTION
Move the validation of `options.exposedTo` origins before attaching the unregister algorithm to `options.signal` in `registerTool()`.

Previously, the abort algorithm was attached to the signal before origin validation. If `exposedTo` contained an invalid or untrustworthy origin, the promise was rejected with a `SecurityError`, but the abort algorithm remained attached to the signal and could inadvertently unregister a subsequently registered tool of the same name upon aborting.

Also reorder `ModelContextRegisterToolOptions` dictionary members and domintro definitions to match the processing order of options.

Fixed in Chromium: https://chromium-review.googlesource.com/c/chromium/src/+/8236351


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/webmcp/pull/240.html" title="Last updated on Aug 14, 2026, 2:46 PM UTC (00a25c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/240/3678f64...beaufortfrancois:00a25c7.html" title="Last updated on Aug 14, 2026, 2:46 PM UTC (00a25c7)">Diff</a>