### PR TITLE
Change `RegisteredTool#inputSchema` type from `DOMString` to `object`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -775,8 +775,9 @@ The <dfn method for=ModelContext>getTools(<var>options</var>)</dfn> method steps
             :: |tool definition|'s [=tool definition/description=]
 
             : {{RegisteredTool/inputSchema}}
-            :: |tool definition|'s [=tool definition/input schema=] if it is not the empty string;
-               otherwise undefined.
+            :: the result of [=parse a JSON string to a JavaScript value=] given |tool
+               definition|'s [=tool definition/input schema=], if |tool definition|'s [=tool
+               definition/input schema=] is not the empty string; otherwise undefined.
 
             : {{RegisteredTool/window}}
             :: |targetDocument|'s [=relevant global object=]
@@ -1121,7 +1122,7 @@ dictionary RegisteredTool {
   // done, and there's no need to do it again on tool exposure.
   DOMString title;
   required DOMString description;
-  DOMString inputSchema;
+  object inputSchema;
   required Window window;
   required USVString origin;
   ToolAnnotations annotations;
@@ -1142,9 +1143,9 @@ dictionary RegisteredTool {
      tool registration, via {{ModelContextTool/description}}.
 
   : <code><var ignore>tool</var>["{{RegisteredTool/inputSchema}}"]</code>
-  :: A stringified JSON Schema object describing the expected input parameters for the tool
-     [[!JSON-SCHEMA]]. It is the string derived from {{ModelContextTool/inputSchema}} during
-     registration.
+  :: A JSON Schema object describing the expected input parameters for the tool
+     [[!JSON-SCHEMA]]. It is the same value provided at tool registration, via
+     {{ModelContextTool/inputSchema}}.
 
   : <code><var ignore>tool</var>["{{RegisteredTool/window}}"]</code>
   :: The {{Window}} of the document that registered the tool.

--- a/index.bs
+++ b/index.bs
@@ -779,6 +779,9 @@ The <dfn method for=ModelContext>getTools(<var>options</var>)</dfn> method steps
                definition|'s [=tool definition/input schema=], if |tool definition|'s [=tool
                definition/input schema=] is not the empty string; otherwise undefined.
 
+               Note: This will never throw an exception, because the string stored in the tool
+               definition is always a valid JSON string.
+
             : {{RegisteredTool/window}}
             :: |targetDocument|'s [=relevant global object=]
 
@@ -1144,7 +1147,7 @@ dictionary RegisteredTool {
 
   : <code><var ignore>tool</var>["{{RegisteredTool/inputSchema}}"]</code>
   :: A JSON Schema object describing the expected input parameters for the tool
-     [[!JSON-SCHEMA]]. It is the same value provided at tool registration, via
+     [[!JSON-SCHEMA]]. It is a deep copy of the schema provided at tool registration, via
      {{ModelContextTool/inputSchema}}.
 
   : <code><var ignore>tool</var>["{{RegisteredTool/window}}"]</code>


### PR DESCRIPTION
As discussed in https://github.com/webmachinelearning/webmcp/issues/237#issuecomment-5267573964, `ModelContextTool#inputSchema` was defined as an `object` during registration, but `RegisteredTool#inputSchema` returned a stringified JSON schema (`DOMString`) from `getTools()`. 
This change aligns `RegisteredTool#inputSchema` to be an `object` (JavaScript object), matching `ModelContextTool#inputSchema` and the [MCP Tool specification](https://modelcontextprotocol.io/specification/latest/server/tools#listing-tools).

Hopefully we'll apply the same reasoning to `executeTool(myTool, {})` instead of `executeTool(myTool, '{}')` in https://github.com/webmachinelearning/webmcp/pull/226/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/webmcp/pull/241.html" title="Last updated on Aug 14, 2026, 3:13 PM UTC (dda8d75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/241/f303c45...beaufortfrancois:dda8d75.html" title="Last updated on Aug 14, 2026, 3:13 PM UTC (dda8d75)">Diff</a>