### PR TITLE
Fix normative defects in tool registration, notification, and observation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -275,7 +275,7 @@ To <dfn>notify documents of a tool change</dfn> given a {{Document}} |tool owner
 1. [=Assert=]: these steps are running [=in parallel=].
 
 1. Let |navigablesToNotify| be |tool owner|'s [=node navigable=]'s [=navigable/traversable
-   navigable=]'s [=Document/descendant navigables=].
+   navigable=]'s [=Document/inclusive descendant navigables=].
 
 1. [=list/For each=] |navigable| of |navigablesToNotify|:
 
@@ -679,7 +679,8 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
    : [=tool definition/exposed origins=]
    :: |exposed origins|
 
-1. Set [=this=]'s [=ModelContext/internal context=][|tool name|] to |tool definition|.
+1. Set [=this=]'s [=ModelContext/internal context=]'s [=model context/tool map=][|tool name|] to
+   |tool definition|.
 
 1. Run the following steps [=in parallel=]:
 
@@ -1280,7 +1281,7 @@ steps:
 
 1. [=Assert=]: This algorithm is running in the [=browser agent=]'s [=AI agent queue=].
 
-1. [=Assert=]: |traversable|'s [=navigable/active document=] is not [=Document/fully active=].
+1. [=Assert=]: |traversable|'s [=navigable/active document=] is [=Document/fully active=].
 
 1. Let |observation| be a new [=observation=].
 
@@ -1289,7 +1290,7 @@ steps:
 
 1. [=list/For each=] [=navigable=] |descendant| of |flat descendants|:
 
-     1. Let |document| be |descendant|'s [=navigable/active document=]'s.
+     1. Let |document| be |descendant|'s [=navigable/active document=].
 
      1. Let |id| be |document|'s [=Document/unique ID=].
 


### PR DESCRIPTION
Three normative fixes, each a case where the algorithm text does not do what the surrounding spec says it does, plus one editorial nit in the same area.

### `registerTool()` writes to the struct instead of its tool map

Fixes #213

A [=model context=] struct has exactly one item, `tool map`, so indexing the struct itself by tool name is not well-defined. Every other algorithm reads through `internal context`'s `tool map` — see `unregister a tool`, `getTools()`, and `perform an observation`.

### `perform an observation` has an inverted assertion

Fixes #214

It asserts the traversable's active document is *not* fully active. A top-level traversable's active document is always fully active, and the algorithm then goes on to read that document's descendants, which only makes sense when it is. `registerTool()`, `getTools()`, and `executeTool()` all reject when a document is *not* fully active.

### `notify documents of a tool change` skips the registering document

Fixes #215

Using `descendant navigables` excludes the tool owner's own navigable, so the document that registered the tool never receives `toolchange`. This contradicts the worked example immediately below the algorithm, which asserts that `Parent toolchange` always logs before `Child toolchange` for a `registerTool()` call on the top-level document. The two comparable algorithms — in `getTools()` and `perform an observation` — both use `inclusive descendant navigables`.

### Editorial

Removes a stray possessive in `perform an observation` (`|descendant|'s active document's.`), matching the identical assignments in `notify documents of a tool change` and `getTools()`.

---

All three normative issues were filed by @Aravindargutus. No new link targets are introduced — every construct used already appears elsewhere in `index.bs`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/emecii/webmcp/pull/244.html" title="Last updated on Aug 16, 2026, 4:54 AM UTC (f2ef15e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/244/384e110...emecii:f2ef15e.html" title="Last updated on Aug 16, 2026, 4:54 AM UTC (f2ef15e)">Diff</a>