### PR TITLE
Add `debugging` member to ToolAnnotations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -211,6 +211,9 @@ An <dfn>annotations</dfn> is a [=struct=] with the following [=struct/items=]:
 
   : <dfn>untrusted content hint</dfn>
   :: a [=boolean=], initially false.
+
+  : <dfn>debugging</dfn>
+  :: a [=boolean=], initially false.
 </dl>
 
 <h3 id="pending-tool-executions">Pending tool executions</h3>
@@ -758,6 +761,9 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
       : [=annotations/untrusted content hint=]
       :: |tool|'s {{ModelContextTool/annotations}}'s {{ToolAnnotations/untrustedContentHint}}
 
+      : [=annotations/debugging=]
+      :: |tool|'s {{ModelContextTool/annotations}}'s {{ToolAnnotations/debugging}}
+
    : [=tool definition/exposed origins=]
    :: |exposed origins|
 
@@ -874,9 +880,11 @@ The <dfn method for=ModelContext>getTools(<var>options</var>)</dfn> method steps
             : {{RegisteredTool/annotations}}
             :: if |tool definition|'s [=tool definition/annotations=] is not null, a
                {{ToolAnnotations}} dictionary whose {{ToolAnnotations/readOnlyHint}} is |tool
-               definition|'s [=tool definition/annotations=]'s [=annotations/read-only hint=] and
+               definition|'s [=tool definition/annotations=]'s [=annotations/read-only hint=],
                {{ToolAnnotations/untrustedContentHint}} is |tool definition|'s [=tool
-               definition/annotations=]'s [=annotations/untrusted content hint=].
+               definition/annotations=]'s [=annotations/untrusted content hint=], and
+               {{ToolAnnotations/debugging}} is |tool definition|'s [=tool
+               definition/annotations=]'s [=annotations/debugging=].
 
          1. [=list/Append=] |registeredTool| to |tools|.
 
@@ -1068,6 +1076,7 @@ dictionary ModelContextTool {
 dictionary ToolAnnotations {
   boolean readOnlyHint = false;
   boolean untrustedContentHint = false;
+  boolean debugging = false;
 };
 
 dictionary ToolExecuteCallbackOptions {
@@ -1124,6 +1133,9 @@ The {{ToolAnnotations}} dictionary provides optional metadata about a tool:
 
   : <code><var ignore>annotations</var>["{{ToolAnnotations/untrustedContentHint}}"]</code>
   :: If true, indicates that the tool's output contains data that is untrusted, from the perspective of the author registering the tool.
+
+  : <code><var ignore>annotations</var>["{{ToolAnnotations/debugging}}"]</code>
+  :: If true, indicates that the tool is intended for debugging and developer tooling rather than end-user interactions.
 </dl>
 
 <h4 id="tool-execute-callback-options">ToolExecuteCallbackOptions Dictionary</h4>

--- a/index.bs
+++ b/index.bs
@@ -215,6 +215,9 @@ An <dfn>annotations</dfn> is a [=struct=] with the following [=struct/items=]:
 
   : <dfn>consequential hint</dfn>
   :: a [=boolean=], initially false.
+
+  : <dfn>debugging</dfn>
+  :: a [=boolean=], initially false.
 </dl>
 
 <h3 id="pending-tool-executions">Pending tool executions</h3>
@@ -765,6 +768,9 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
       : [=annotations/consequential hint=]
       :: |tool|'s {{ModelContextTool/annotations}}'s {{ToolAnnotations/consequentialHint}}
 
+      : [=annotations/debugging=]
+      :: |tool|'s {{ModelContextTool/annotations}}'s {{ToolAnnotations/debugging}}
+
    : [=tool definition/exposed origins=]
    :: |exposed origins|
 
@@ -883,9 +889,11 @@ The <dfn method for=ModelContext>getTools(<var>options</var>)</dfn> method steps
                {{ToolAnnotations}} dictionary whose {{ToolAnnotations/readOnlyHint}} is |tool
                definition|'s [=tool definition/annotations=]'s [=annotations/read-only hint=],
                {{ToolAnnotations/untrustedContentHint}} is |tool definition|'s [=tool
-               definition/annotations=]'s [=annotations/untrusted content hint=], and
+               definition/annotations=]'s [=annotations/untrusted content hint=],
                {{ToolAnnotations/consequentialHint}} is |tool definition|'s [=tool
-               definition/annotations=]'s [=annotations/consequential hint=].
+               definition/annotations=]'s [=annotations/consequential hint=], and
+               {{ToolAnnotations/debugging}} is |tool definition|'s [=tool
+               definition/annotations=]'s [=annotations/debugging=].
 
          1. [=list/Append=] |registeredTool| to |tools|.
 
@@ -1080,6 +1088,7 @@ dictionary ToolAnnotations {
   boolean readOnlyHint = false;
   boolean untrustedContentHint = false;
   boolean consequentialHint = false;
+  boolean debugging = false;
 };
 
 dictionary ToolExecuteCallbackOptions {
@@ -1139,6 +1148,9 @@ The {{ToolAnnotations}} dictionary provides optional metadata about a tool:
 
   : <code><var ignore>annotations</var>["{{ToolAnnotations/consequentialHint}}"]</code>
   :: If true, indicates that executing the tool will result in consequential actions that are significant, real-world, or non-reversible, ex: booking a flight, transferring money.
+
+  : <code><var ignore>annotations</var>["{{ToolAnnotations/debugging}}"]</code>
+  :: If true, indicates that the tool is intended for debugging and developer tooling rather than end-user interactions.
 </dl>
 
 <h4 id="tool-execute-callback-options">ToolExecuteCallbackOptions Dictionary</h4>


### PR DESCRIPTION
Following the [WebML CG resolution](https://www.w3.org/2026/08/20-webmachinelearning-minutes.html#73b8), this PR adds a `debugging` boolean member to the `ToolAnnotations` dictionary to provide a way for web apps and frameworks to register tools intended specifically for developer tooling and inspection (e.g., Chrome DevTools AI assistance, testing frameworks) so that general-purpose/end-user agents can filter them out.

Note that I went with `debugging` rather than `debuggingHint` because it is a definitive categorization flag identifying the tool's intended domain/audience (developer/debugging tools vs. user-facing tools) rather than a behavioral hint about how the tool executes.

Fixes #207


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/webmcp/pull/253.html" title="Last updated on Sep 11, 2026, 11:20 AM UTC (c768a6b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/253/97da8f5...beaufortfrancois:c768a6b.html" title="Last updated on Sep 11, 2026, 11:20 AM UTC (c768a6b)">Diff</a>