### PR TITLE
Add `outputSchema` to `ModelContextTool` and `RegisteredTool`

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Any document in the tree matching these origins (and allowed to use `tools` perm
 
 Once tools are registered, in-page agents can discover and invoke them using `getTools()` and `executeTool()`.
 
-Calling `document.modelContext.getTools()` returns a promise that resolves with an array of `RegisteredTool` dictionary objects. Each object contains the tool's `name`, `description`, `inputSchema`, `origin`, and owner `window`. By default, `getTools()` only returns tools registered by documents same-origin with the caller in the frame tree. To retrieve cross-origin tools, you must explicitly list their origins in the `fromOrigins` option. This array only supports secure origins.
+Calling `document.modelContext.getTools()` returns a promise that resolves with an array of `RegisteredTool` dictionary objects. Each object contains the tool's `name`, `description`, `inputSchema`, `outputSchema`, `origin`, and owner `window`. By default, `getTools()` only returns tools registered by documents same-origin with the caller in the frame tree. To retrieve cross-origin tools, you must explicitly list their origins in the `fromOrigins` option. This array only supports secure origins.
 
 ```js
 // Discover tools exposed by same-origin frames in the tree (default)
@@ -357,6 +357,7 @@ for (const tool of tools) {
   console.log(`Tool: ${tool.name} (from ${tool.origin})`);
   console.log(`Description: ${tool.description}`);
   console.log(`Parameters schema:`, tool.inputSchema);
+  console.log(`Output schema:`, tool.outputSchema);
 }
 
 // Discover additional tools provided by a cross-origin frame (in addition to
@@ -479,8 +480,6 @@ As the WebMCP proposal continues to evolve with community and stakeholder feedba
 - **Input and output schema validation**: Investigating native validation of tool inputs and outputs against declared JSON schemas before invoking the page's JS execution callback, or letting the output reach the model. See [Issue #92](https://github.com/webmachinelearning/webmcp/issues/92).
 
 - **Skills Integration**: Determining if the author should expose a higher-level "skill" to help the agent coordinate multiple related tools to fulfill a user journey. See [Issue #161](https://github.com/webmachinelearning/webmcp/issues/161).
-
-- **Output schema**: Supporting structured `outputSchema` contracts (complementing `inputSchema`) to help LLMs reliably reason about the return values of tools. See [Issue #9](https://github.com/webmachinelearning/webmcp/issues/9).
 
 - **User prompting and elicitation**: Exploring a way for a tool to prompt the user for confirmation when tools require explicit user authorization. This could be done by delegating to the agent and its harness, or by invoking native browser permission dialogue outside of the agent loop. See [Issue #165](https://github.com/webmachinelearning/webmcp/issues/165) and [Issue #50](https://github.com/webmachinelearning/webmcp/issues/50) for discussion about the `ModelContextClient` interface.
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Any document in the tree matching these origins (and allowed to use `tools` perm
 
 Once tools are registered, in-page agents can discover and invoke them using `getTools()` and `executeTool()`.
 
-Calling `document.modelContext.getTools()` returns a promise that resolves with an array of `RegisteredTool` dictionary objects. Each object contains the tool's `name`, `description`, `inputSchema`, `origin`, and owner `window`. By default, `getTools()` only returns tools registered by documents same-origin with the caller in the frame tree. To retrieve cross-origin tools, you must explicitly list their origins in the `fromOrigins` option. This array only supports secure origins.
+Calling `document.modelContext.getTools()` returns a promise that resolves with an array of `RegisteredTool` dictionary objects. Each object contains the tool's `name`, `description`, `inputSchema`, `outputSchema`, `origin`, and owner `window`. By default, `getTools()` only returns tools registered by documents same-origin with the caller in the frame tree. To retrieve cross-origin tools, you must explicitly list their origins in the `fromOrigins` option. This array only supports secure origins.
 
 ```js
 // Discover tools exposed by same-origin frames in the tree (default)
@@ -365,6 +365,7 @@ for (const tool of tools) {
   console.log(`Tool: ${tool.name} (from ${tool.origin})`);
   console.log(`Description: ${tool.description}`);
   console.log(`Parameters schema:`, tool.inputSchema);
+  console.log(`Output schema:`, tool.outputSchema);
 }
 
 // Discover additional tools provided by a cross-origin frame (in addition to
@@ -517,8 +518,6 @@ As the WebMCP proposal continues to evolve with community and stakeholder feedba
 - **Input and output schema validation**: Investigating native validation of tool inputs and outputs against declared JSON schemas before invoking the page's JS execution callback, or letting the output reach the model. See [Issue #92](https://github.com/webmachinelearning/webmcp/issues/92).
 
 - **Skills Integration**: Determining if the author should expose a higher-level "skill" to help the agent coordinate multiple related tools to fulfill a user journey. See [Issue #161](https://github.com/webmachinelearning/webmcp/issues/161).
-
-- **Output schema**: Supporting structured `outputSchema` contracts (complementing `inputSchema`) to help LLMs reliably reason about the return values of tools. See [Issue #9](https://github.com/webmachinelearning/webmcp/issues/9).
 
 - **User prompting and elicitation**: Exploring a way for a tool to prompt the user for confirmation when tools require explicit user authorization. This could be done by delegating to the agent and its harness, or by invoking native browser permission dialogue outside of the agent loop. See [Issue #165](https://github.com/webmachinelearning/webmcp/issues/165) and [Issue #50](https://github.com/webmachinelearning/webmcp/issues/50) for discussion about the `ModelContextClient` interface.
 

--- a/index.bs
+++ b/index.bs
@@ -172,11 +172,20 @@ A <dfn>tool definition</dfn> is a [=struct=] with the following [=struct/items=]
 
      Note: For tools registered by the imperative form of this API (i.e.,
      {{ModelContext/registerTool()}}), this is the stringified representation of
-     {{ModelContextTool/inputSchema}}. For tools registered
+     {{ModelContextTool/inputSchema}}, created by the [=serialize a tool schema=]
+     algorithm. For tools registered
      [declaratively](https://github.com/webmachinelearning/webmcp/pull/76), this will be a
      stringified JSON Schema object created by the
      [=synthesize a declarative JSON Schema object algorithm=].
      [[!JSON-SCHEMA]]
+
+  : <dfn>output schema</dfn>
+  :: a [=string=].
+
+     Note: For tools registered by the imperative form of this API (i.e.,
+     {{ModelContext/registerTool()}}), this is the stringified representation of
+     {{ModelContextTool/outputSchema}}, created by the [=serialize a tool schema=]
+     algorithm.
 
   : <dfn>execute steps</dfn>
   :: an algorithm that takes a {{Document}} <var ignore>targetDocument</var>, a [=string=] <var
@@ -561,6 +570,31 @@ To <dfn for="model context">unregister a tool</dfn> given a {{ModelContext}} |mo
 
 </div>
 
+<div algorithm>
+To <dfn>serialize a tool schema</dfn> given a {{ModelContextTool}} |tool|'s
+{{ModelContextTool/inputSchema}} or {{ModelContextTool/outputSchema}} |schema|:
+
+1. If |tool|'s |schema| does not [=map/exist=], then return the empty string.
+
+1. Return the result of [=serializing a JavaScript value to a JSON string=] given |tool|'s |schema|.
+
+<div class="note">
+  <p>The [=serialize a JavaScript value to a JSON string=] algorithm throws exceptions in the
+  following cases:</p>
+
+  <ol>
+    <li><p><i>Throws a new {{TypeError}}</i> when the backing "<code>JSON.stringify()</code>"
+    yields undefined, e.g.,
+    "<code>inputSchema: { toJSON() {return HTMLDivElement;}}</code>", or
+    "<code>outputSchema: { toJSON() {return undefined;}}</code>".</p></li>
+
+    <li><p><i>Re-throws exceptions</i> thrown by "<code>JSON.stringify()</code>", e.g., when
+    |tool|'s |schema| is an object with a circular reference, etc.</p></li>
+  </ol>
+</div>
+
+</div>
+
 
 <h2 id="api">API</h2>
 
@@ -620,7 +654,7 @@ is a [=model context=] [=struct=] created alongside the {{ModelContext}}.
     <p>Registers a tool that [=agents=] can invoke. Returns a rejected promise if a tool with the
     same name is already registered, if the given {{ModelContextTool/name}} or
     {{ModelContextTool/description}} are empty strings, or if the {{ModelContextTool/inputSchema}}
-    is invalid.</p>
+    or {{ModelContextTool/outputSchema}} is invalid.</p>
   </dd>
 
   <dt><code><var ignore>document</var>.{{Document/modelContext}}.{{ModelContext/getTools(options)}}</code></dt>
@@ -674,26 +708,13 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
    U+002D (-), or U+002E (.), then return [=a promise rejected with=] an {{InvalidStateError}}
    {{DOMException}}.
 
-1. Let |stringified input schema| be the empty string.
+1. Let |stringified input schema| be the result of [=serializing a tool schema=]
+   given |tool|'s {{ModelContextTool/inputSchema}}. If this threw an exception, then return [=a
+   promise rejected with=] that exception.
 
-1. If |tool|'s {{ModelContextTool/inputSchema}} [=map/exists=], then set |stringified input schema|
-   to the result of [=serializing a JavaScript value to a JSON string=], given |tool|'s
-   {{ModelContextTool/inputSchema}}. If this threw an exception, then return [=a promise rejected
-   with=] that exception.
-
-   <div class="note">
-     <p>The serialization algorithm above throws exceptions in the following cases:</p>
-
-     <ol>
-       <li><p><i>Throws a new {{TypeError}}</i> when the backing "<code>JSON.stringify()</code>"
-       yields undefined, e.g.,
-       "<code>inputSchema: { toJSON() {return HTMLDivElement;}}</code>", or
-       "<code>inputSchema: { toJSON() {return undefined;}}</code>".</p></li>
-
-       <li><p><i>Re-throws exceptions</i> thrown by "<code>JSON.stringify()</code>", e.g., when
-       "<code>inputSchema</code>" is an object with a circular reference, etc.</p></li>
-     </ol>
-   </div>
+1. Let |stringified output schema| be the result of [=serializing a tool schema=]
+   given |tool|'s {{ModelContextTool/outputSchema}}. If this threw an exception, then return [=a
+   promise rejected with=] that exception.
 
 1. If |options|'s {{ModelContextRegisterToolOptions/signal}} [=map/exists=] and is
    [=AbortSignal/aborted=], then return [=a promise rejected with=] |options|'s
@@ -741,6 +762,9 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 
    : [=tool definition/input schema=]
    :: |stringified input schema|
+
+   : [=tool definition/output schema=]
+   :: |stringified output schema|
 
    : [=tool definition/execute steps=]
    :: An algorithm that takes a {{Document}} |targetDocument|, a [=string=] |inputArguments|, an
@@ -861,6 +885,14 @@ The <dfn method for=ModelContext>getTools(<var>options</var>)</dfn> method steps
             :: the result of [=parse a JSON string to a JavaScript value=] given |tool
                definition|'s [=tool definition/input schema=], if |tool definition|'s [=tool
                definition/input schema=] is not the empty string; otherwise undefined.
+
+               Note: This will never throw an exception, because the string stored in the tool
+               definition is always a valid JSON string.
+
+            : {{RegisteredTool/outputSchema}}
+            :: the result of [=parse a JSON string to a JavaScript value=] given |tool
+               definition|'s [=tool definition/output schema=], if |tool definition|'s [=tool
+               definition/output schema=] is not the empty string; otherwise undefined.
 
                Note: This will never throw an exception, because the string stored in the tool
                definition is always a valid JSON string.
@@ -1061,6 +1093,7 @@ dictionary ModelContextTool {
   USVString title;
   required DOMString description;
   object inputSchema;
+  object outputSchema;
   required ToolExecuteCallback execute;
   ToolAnnotations annotations;
 };
@@ -1100,6 +1133,13 @@ callback ToolExecuteCallback = Promise<any> (object inputObject, ToolExecuteCall
   <dt><code><var ignore>tool</var>["{{ModelContextTool/inputSchema}}"]</code></dt>
   <dd>
     <p>A JSON Schema object describing the expected input parameters for the tool [[!JSON-SCHEMA]].
+  </dd>
+
+  <dt><code><var ignore>tool</var>["{{ModelContextTool/outputSchema}}"]</code></dt>
+  <dd>
+    <p>A JSON Schema object describing the expected output structure for the tool [[!JSON-SCHEMA]],
+    so that [=agents=] may use it to insert an [=implementation-defined=] message to guide the
+    language model’s behavior.
   </dd>
 
   <dt><code><var ignore>tool</var>["{{ModelContextTool/execute}}"]</code></dt>
@@ -1205,6 +1245,7 @@ dictionary RegisteredTool {
   DOMString title;
   required DOMString description;
   object inputSchema;
+  object outputSchema;
   required Window window;
   required USVString origin;
   ToolAnnotations annotations;
@@ -1228,6 +1269,12 @@ dictionary RegisteredTool {
   :: A JSON Schema object describing the expected input parameters for the tool
      [[!JSON-SCHEMA]]. It is a deep copy of the schema provided at tool registration, via
      {{ModelContextTool/inputSchema}}.
+
+  : <code><var ignore>tool</var>["{{RegisteredTool/outputSchema}}"]</code>
+  :: A JSON Schema object describing the expected output structure for the tool [[!JSON-SCHEMA]], so
+     that [=agents=] may use it to insert an [=implementation-defined=] message to guide the
+     language model’s behavior. It is a deep copy of the schema provided at tool registration, via
+     {{ModelContextTool/outputSchema}}.
 
   : <code><var ignore>tool</var>["{{RegisteredTool/window}}"]</code>
   :: The {{Window}} of the document that registered the tool.

--- a/index.bs
+++ b/index.bs
@@ -173,11 +173,20 @@ A <dfn>tool definition</dfn> is a [=struct=] with the following [=struct/items=]
 
      Note: For tools registered by the imperative form of this API (i.e.,
      {{ModelContext/registerTool()}}), this is the stringified representation of
-     {{ModelContextTool/inputSchema}}. For tools registered
+     {{ModelContextTool/inputSchema}}, created by the [=serialize a tool schema=]
+     algorithm. For tools registered
      [declaratively](https://github.com/webmachinelearning/webmcp/blob/main/declarative-api-explainer.md), this will be a
      stringified JSON Schema object created by the
      [=synthesize a declarative JSON Schema object algorithm=].
      [[!JSON-SCHEMA]]
+
+  : <dfn>output schema</dfn>
+  :: a [=string=].
+
+     Note: For tools registered by the imperative form of this API (i.e.,
+     {{ModelContext/registerTool()}}), this is the stringified representation of
+     {{ModelContextTool/outputSchema}}, created by the [=serialize a tool schema=]
+     algorithm.
 
   : <dfn>execute steps</dfn>
   :: an algorithm that takes a {{Document}} <var ignore>targetDocument</var>, a [=string=] <var
@@ -565,6 +574,31 @@ To <dfn for="model context">unregister a tool</dfn> given a {{ModelContext}} |mo
 
 </div>
 
+<div algorithm>
+To <dfn>serialize a tool schema</dfn> given a {{ModelContextTool}} |tool|'s
+{{ModelContextTool/inputSchema}} or {{ModelContextTool/outputSchema}} |schema|:
+
+1. If |tool|'s |schema| does not [=map/exist=], then return the empty string.
+
+1. Return the result of [=serializing a JavaScript value to a JSON string=] given |tool|'s |schema|.
+
+<div class="note">
+  <p>The [=serialize a JavaScript value to a JSON string=] algorithm throws exceptions in the
+  following cases:</p>
+
+  <ol>
+    <li><p><i>Throws a new {{TypeError}}</i> when the backing "<code>JSON.stringify()</code>"
+    yields undefined, e.g.,
+    "<code>inputSchema: { toJSON() {return HTMLDivElement;}}</code>", or
+    "<code>outputSchema: { toJSON() {return undefined;}}</code>".</p></li>
+
+    <li><p><i>Re-throws exceptions</i> thrown by "<code>JSON.stringify()</code>", e.g., when
+    |tool|'s |schema| is an object with a circular reference, etc.</p></li>
+  </ol>
+</div>
+
+</div>
+
 
 <h2 id="api">API</h2>
 
@@ -624,7 +658,7 @@ is a [=model context=] [=struct=] created alongside the {{ModelContext}}.
     <p>Registers a tool that [=agents=] can invoke. Returns a rejected promise if a tool with the
     same name is already registered, if the given {{ModelContextTool/name}} or
     {{ModelContextTool/description}} are empty strings, or if the {{ModelContextTool/inputSchema}}
-    is invalid.</p>
+    or {{ModelContextTool/outputSchema}} is invalid.</p>
   </dd>
 
   <dt><code><var ignore>document</var>.{{Document/modelContext}}.{{ModelContext/getTools(options)}}</code></dt>
@@ -678,26 +712,13 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
    U+002D (-), or U+002E (.), then return [=a promise rejected with=] an {{InvalidStateError}}
    {{DOMException}}.
 
-1. Let |stringified input schema| be the empty string.
+1. Let |stringified input schema| be the result of [=serializing a tool schema=]
+   given |tool|'s {{ModelContextTool/inputSchema}}. If this threw an exception, then return [=a
+   promise rejected with=] that exception.
 
-1. If |tool|'s {{ModelContextTool/inputSchema}} [=map/exists=], then set |stringified input schema|
-   to the result of [=serializing a JavaScript value to a JSON string=], given |tool|'s
-   {{ModelContextTool/inputSchema}}. If this threw an exception, then return [=a promise rejected
-   with=] that exception.
-
-   <div class="note">
-     <p>The serialization algorithm above throws exceptions in the following cases:</p>
-
-     <ol>
-       <li><p><i>Throws a new {{TypeError}}</i> when the backing "<code>JSON.stringify()</code>"
-       yields undefined, e.g.,
-       "<code>inputSchema: { toJSON() {return HTMLDivElement;}}</code>", or
-       "<code>inputSchema: { toJSON() {return undefined;}}</code>".</p></li>
-
-       <li><p><i>Re-throws exceptions</i> thrown by "<code>JSON.stringify()</code>", e.g., when
-       "<code>inputSchema</code>" is an object with a circular reference, etc.</p></li>
-     </ol>
-   </div>
+1. Let |stringified output schema| be the result of [=serializing a tool schema=]
+   given |tool|'s {{ModelContextTool/outputSchema}}. If this threw an exception, then return [=a
+   promise rejected with=] that exception.
 
 1. If |options|'s {{ModelContextRegisterToolOptions/signal}} [=map/exists=] and is
    [=AbortSignal/aborted=], then return [=a promise rejected with=] |options|'s
@@ -745,6 +766,9 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 
    : [=tool definition/input schema=]
    :: |stringified input schema|
+
+   : [=tool definition/output schema=]
+   :: |stringified output schema|
 
    : [=tool definition/execute steps=]
    :: An algorithm that takes a {{Document}} |targetDocument|, a [=string=] |inputArguments|, an
@@ -868,6 +892,14 @@ The <dfn method for=ModelContext>getTools(<var>options</var>)</dfn> method steps
             :: the result of [=parse a JSON string to a JavaScript value=] given |tool
                definition|'s [=tool definition/input schema=], if |tool definition|'s [=tool
                definition/input schema=] is not the empty string; otherwise undefined.
+
+               Note: This will never throw an exception, because the string stored in the tool
+               definition is always a valid JSON string.
+
+            : {{RegisteredTool/outputSchema}}
+            :: the result of [=parse a JSON string to a JavaScript value=] given |tool
+               definition|'s [=tool definition/output schema=], if |tool definition|'s [=tool
+               definition/output schema=] is not the empty string; otherwise undefined.
 
                Note: This will never throw an exception, because the string stored in the tool
                definition is always a valid JSON string.
@@ -1072,6 +1104,7 @@ dictionary ModelContextTool {
   USVString title;
   required DOMString description;
   object inputSchema;
+  object outputSchema;
   required ToolExecuteCallback execute;
   ToolAnnotations annotations;
 };
@@ -1112,6 +1145,13 @@ callback ToolExecuteCallback = Promise<any> (object inputObject, ToolExecuteCall
   <dt><code><var ignore>tool</var>["{{ModelContextTool/inputSchema}}"]</code></dt>
   <dd>
     <p>A JSON Schema object describing the expected input parameters for the tool [[!JSON-SCHEMA]].
+  </dd>
+
+  <dt><code><var ignore>tool</var>["{{ModelContextTool/outputSchema}}"]</code></dt>
+  <dd>
+    <p>A JSON Schema object describing the expected output structure for the tool [[!JSON-SCHEMA]],
+    so that [=agents=] may use it to insert an [=implementation-defined=] message to guide the
+    language model’s behavior.
   </dd>
 
   <dt><code><var ignore>tool</var>["{{ModelContextTool/execute}}"]</code></dt>
@@ -1220,6 +1260,7 @@ dictionary RegisteredTool {
   DOMString title;
   required DOMString description;
   object inputSchema;
+  object outputSchema;
   required Window window;
   required USVString origin;
   ToolAnnotations annotations;
@@ -1243,6 +1284,12 @@ dictionary RegisteredTool {
   :: A JSON Schema object describing the expected input parameters for the tool
      [[!JSON-SCHEMA]]. It is a deep copy of the schema provided at tool registration, via
      {{ModelContextTool/inputSchema}}.
+
+  : <code><var ignore>tool</var>["{{RegisteredTool/outputSchema}}"]</code>
+  :: A JSON Schema object describing the expected output structure for the tool [[!JSON-SCHEMA]], so
+     that [=agents=] may use it to insert an [=implementation-defined=] message to guide the
+     language model’s behavior. It is a deep copy of the schema provided at tool registration, via
+     {{ModelContextTool/outputSchema}}.
 
   : <code><var ignore>tool</var>["{{RegisteredTool/window}}"]</code>
   :: The {{Window}} of the document that registered the tool.

--- a/security-privacy-questionnaire.md
+++ b/security-privacy-questionnaire.md
@@ -101,7 +101,7 @@ Note: this behavior is not yet spec'd but is the intended direction.
 
 > 20. Does your spec define when and how new kinds of errors should be raised?
 
-Yes. `registerTool()` throws `InvalidStateError` for inactive documents, duplicate names, or invalid name/description; `NotAllowedError` when the `"tools"` Permissions Policy is disallowed; `SecurityError` for non-trustworthy [`exposedTo`](https://webmachinelearning.github.io/webmcp/#dom-modelcontextregistertooloptions-exposedto) origins; and `TypeError` when `inputSchema` serialization fails. These errors only reflect the page's own state and inputs, so they do not leak new information.
+Yes. `registerTool()` throws `InvalidStateError` for inactive documents, duplicate names, or invalid name/description; `NotAllowedError` when the `"tools"` Permissions Policy is disallowed; `SecurityError` for non-trustworthy [`exposedTo`](https://webmachinelearning.github.io/webmcp/#dom-modelcontextregistertooloptions-exposedto) origins; and `TypeError` when `inputSchema` or `outputSchema` serialization fails. These errors only reflect the page's own state and inputs, so they do not leak new information.
 
 > 21. Does your feature allow sites to learn about the user's use of assistive technology?
 


### PR DESCRIPTION
This PR adds an optional `outputSchema` member to the `ModelContextTool` and `RegisteredTool` dictionaries to enable browser agents and in-page agents to help LLMs reliably reason about the return values of tools.

While [`responseConstraint`](https://webmachinelearning.github.io/prompt-api/#dom-languagemodelpromptoptions-responseconstraint) was previously discussed, that name is too specific to the Built-in AI / Prompt API. The`outputSchema` name aligns directly with the [MCP Tools specification `outputSchema`](https://modelcontextprotocol.io/specification/draft/server/tools#output-schema) used to define expected structured outputs with JSON Schema.

FIX #9


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/webmcp/pull/254.html" title="Last updated on Sep 11, 2026, 10:00 AM UTC (a988ee0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/254/97da8f5...beaufortfrancois:a988ee0.html" title="Last updated on Sep 11, 2026, 10:00 AM UTC (a988ee0)">Diff</a>