### PR TITLE
Drop closed executeTool issue links from explainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,12 +311,7 @@ The reason WebMCP is not limited to only declarative form tools is for the same 
 
 ### Permissions policy and iframes
 
-While much of this explainer assumes integration with built-in browser agents, WebMCP also supports **author-provided agents**, such as agents embedded directly on a page or running in an iframe, that can collaborate with parent frames and nested contexts. See:
- - [Issue #57](https://github.com/webmachinelearning/webmcp/issues/57)
- - [Issue #117](https://github.com/webmachinelearning/webmcp/issues/117)
- - [Issue #159](https://github.com/webmachinelearning/webmcp/issues/159)
- - [Issue #160](https://github.com/webmachinelearning/webmcp/issues/160)
- - [Issue #178](https://github.com/webmachinelearning/webmcp/issues/178)
+While much of this explainer assumes integration with built-in browser agents, WebMCP also supports **author-provided agents**, such as agents embedded directly on a page or running in an iframe, that can collaborate with parent frames and nested contexts.
 
 By default, WebMCP is enabled in top-level `Window`s and its same-origin iframes, but access can be delegated to cross-origin iframes using the [Permissions Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Permissions_Policy) `allow="tools"`:
 

--- a/declarative-api-explainer.md
+++ b/declarative-api-explainer.md
@@ -206,7 +206,8 @@ It's an open question as to whether [an
 WebMCP tools, and therefore if the `agentResponse` Promise passed to `SubmitEvent#respondWith()`
 must resolve to an object conforming to such schema.
 
-It is TBD how *declarative* WebMCP tools will be exposed to any interface that exposes a site's
-tools to JavaScript. See https://github.com/webmachinelearning/webmcp/issues/51 for context. Should
-a declarative WebMCP tool be able to be invoked from such an interface, should it exist in the
-future? Almost certainly, yes. But details are TBD.
+In-page agents can discover and run imperative tools with
+[`getTools()`](https://webmachinelearning.github.io/webmcp/#dom-modelcontext-gettools) and
+[`executeTool()`](https://webmachinelearning.github.io/webmcp/#dom-modelcontext-executetool). How
+*declarative* tools show up there is still TBD. Should they be invokable from that interface?
+Almost certainly, yes. But details are TBD.

--- a/index.bs
+++ b/index.bs
@@ -173,7 +173,7 @@ A <dfn>tool definition</dfn> is a [=struct=] with the following [=struct/items=]
      Note: For tools registered by the imperative form of this API (i.e.,
      {{ModelContext/registerTool()}}), this is the stringified representation of
      {{ModelContextTool/inputSchema}}. For tools registered
-     [declaratively](https://github.com/webmachinelearning/webmcp/pull/76), this will be a
+     [declaratively](https://github.com/webmachinelearning/webmcp/blob/main/declarative-api-explainer.md), this will be a
      stringified JSON Schema object created by the
      [=synthesize a declarative JSON Schema object algorithm=].
      [[!JSON-SCHEMA]]
@@ -185,7 +185,7 @@ A <dfn>tool definition</dfn> is a [=struct=] with the following [=struct/items=]
 
      Note: For tools registered imperatively, these steps will simply invoke the [=imperative
      execute steps=]. For tools registered
-     [declaratively](https://github.com/webmachinelearning/webmcp/pull/76), this will be a set of
+     [declaratively](https://github.com/webmachinelearning/webmcp/blob/main/declarative-api-explainer.md), this will be a set of
      "internal" steps that have not been defined yet, that describe how to fill out a <{form}> and
      its [=form-associated elements=].
 
@@ -1247,7 +1247,7 @@ dictionary RegisteredTool {
 
 <h3 id="declarative-api">Declarative WebMCP</h3>
 
-This section is entirely a TODO. For now, refer to the [explainer draft](https://github.com/webmachinelearning/webmcp/pull/76).
+This section is entirely a TODO. For now, refer to the [Declarative API explainer](https://github.com/webmachinelearning/webmcp/blob/main/declarative-api-explainer.md).
 
 <div algorithm>
 The <dfn>synthesize a declarative JSON Schema object algorithm</dfn>, given a <{form}> element


### PR DESCRIPTION
PR #226 closed #51, #57, #117, #159, and #160. The explainers still listed those as open questions.

This drops the closed links and points the spec at declarative-api-explainer.md instead of PR #76.

#178 is still open; I left it out of the iframe "See:" list because the remaining ask is deployer guidance, not getTools()/executeTool(). #182 is unchanged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/HaoChiBao/webmcp/pull/259.html" title="Last updated on Aug 25, 2026, 10:39 PM UTC (bdb74b7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/259/fca7462...HaoChiBao:bdb74b7.html" title="Last updated on Aug 25, 2026, 10:39 PM UTC (bdb74b7)">Diff</a>