### PR TITLE
Clarify observation context management

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1351,6 +1351,12 @@ often includes screenshots of the page, not just a DOM serialization. See [Annot
 (APC)](https://chromium.googlesource.com/chromium/src.git/+/main/third_party/blink/renderer/modules/content_extraction/readme.md)
 in the Chromium project for an example of what might contribute to an observation.
 
+Note: Including a complete [=observation/tool map=] in each [=observation=] does not require an agent
+implementation to repeatedly append that map verbatim to a backing model's input. Implementations
+can diff, cache, filter, or otherwise absorb repeated observations before incorporating relevant
+information into an agent's working context. Such absorption and context-management strategies are
+agent product decisions and are outside the scope of this specification.
+
 <hr>
 
 <div algorithm>


### PR DESCRIPTION
Fixes #231.

## Summary

This adds a non-normative clarification to the page-observation section:

- an observation still contains the complete tool map required by the current specification;
- this does not require an agent implementation to append that map verbatim to model input repeatedly;
- diffing, caching, filtering, and absorbing repeated observations are agent-product context-management choices outside WebMCP conformance.

## Scope

The change does not alter observation timing, remove the complete tool map, or attempt to resolve the adjacent application-driven observation and session/compaction discussions in #229 and #232.

## Validation

- CSSWG Bikeshed API build: HTTP 200
- `git diff --check`: clean


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/1aifanatic/webmcp/pull/264.html" title="Last updated on Aug 27, 2026, 4:11 PM UTC (37e0f00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/264/41d12f0...1aifanatic:37e0f00.html" title="Last updated on Aug 27, 2026, 4:11 PM UTC (37e0f00)">Diff</a>