### PR TITLE
Define input-length mitigations in code points

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1775,11 +1775,11 @@ respective private browsing modes are safely exposed to [=agents=] and that thes
 
 <h4 id="mitigation-restrict-input-lengths">Restricting maximum input lengths</h4>
 
-**What:** Restrict the maximum amount of characters
+**What:** Restrict the maximum number of code points
 
 **Threats addressed:** [[#metadata-description-attacks]]
 
-**How:** This restriction would not fully solve prompt injection attacks but helps shrink the possible universe of attacks, preventing longer prompts that leverage e.g. repetition and sockpuppetting [[SOCKPUPPETTING]] to convince agents of malicious tasks. The specification already implements a nominal size restriction of 128 characters for the tool {{ModelContextTool/name}} (see [[#supporting-concepts]]), but further work is needed to evaluate the right size limits for titles, names, and other inputs. See [Issue #73](https://github.com/webmachinelearning/webmcp/issues/73).
+**How:** This restriction would not fully solve prompt injection attacks but helps shrink the possible universe of attacks, preventing longer prompts that leverage e.g. repetition and sockpuppetting [[SOCKPUPPETTING]] to convince agents of malicious tasks. The specification already implements a nominal size restriction of 128 ASCII [=code points=] for the tool {{ModelContextTool/name}} (see [[#supporting-concepts]]), but further work is needed to evaluate the right size limits for titles, names, and other inputs. See [Issue #73](https://github.com/webmachinelearning/webmcp/issues/73).
 
 <h4 id="mitigation-shared-attack-evals">Supporting interoperable probabilistic defense structures through shared attack eval datasets</h4>
 


### PR DESCRIPTION
Fixes #219.

The mitigation section said "characters". The name rule already uses ASCII code points and a 128 limit.

This updates the mitigation wording to match. New limits for titles and other inputs stay with #73.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/HaoChiBao/webmcp/pull/265.html" title="Last updated on Aug 27, 2026, 7:56 PM UTC (6412c2c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/265/41d12f0...HaoChiBao:6412c2c.html" title="Last updated on Aug 27, 2026, 7:56 PM UTC (6412c2c)">Diff</a>