### PR TITLE
Drop the stale native-agents note from the security questionnaire

### DIFF
--- a/security-privacy-questionnaire.md
+++ b/security-privacy-questionnaire.md
@@ -72,7 +72,7 @@ None.
 
 The feature is gated by the [`"tools"`](https://webmachinelearning.github.io/webmcp/#permissiondef-tools) permission policy. It is allowed in top-level documents and same-origin descendants by default; The permission policy can be used to allow it in cross-origin iframes and/or to disallow it in same-origin frames.
 
-Additionally, tools can specify [`exposedTo`](https://webmachinelearning.github.io/webmcp/#dom-modelcontextregistertooloptions-exposedto) to control which origins (or `native-agents`, name to be bikeshed per [#179](https://github.com/webmachinelearning/webmcp/pull/179)) can discover them.
+Additionally, tools can specify [`exposedTo`](https://webmachinelearning.github.io/webmcp/#dom-modelcontextregistertooloptions-exposedto) to control which origins can discover them.
 
 > 15. How do the features in this specification work in the context of a browser's Private Browsing or Incognito mode?
 

--- a/security-privacy-questionnaire.md
+++ b/security-privacy-questionnaire.md
@@ -72,7 +72,7 @@ None.
 
 The feature is gated by the [`"tools"`](https://webmachinelearning.github.io/webmcp/#permissiondef-tools) permission policy. It is allowed in top-level documents and same-origin descendants by default; The permission policy can be used to allow it in cross-origin iframes and/or to disallow it in same-origin frames.
 
-Additionally, tools can specify [`exposedTo`](https://webmachinelearning.github.io/webmcp/#dom-modelcontextregistertooloptions-exposedto) to control which origins can discover them.
+Additionally, tools can specify [`exposedTo`](https://webmachinelearning.github.io/webmcp/#dom-modelcontextregistertooloptions-exposedto) to control which origins can discover them. Whether tool authors in cross origin iframes can explicitly control exposure to the browser's built in agent, for example through a `native-agent` keyword, is an open design question tracked under [Built-in agent exposure by default](https://github.com/webmachinelearning/webmcp/blob/main/README.md#built-in-agent-default-exposure) in the README.
 
 > 15. How do the features in this specification work in the context of a browser's Private Browsing or Incognito mode?
 


### PR DESCRIPTION
The security questionnaire says `exposedTo` controls which origins (or `native-agents`, name to be bikeshed per #179) can discover tools. That parenthetical is stale: #179 merged in May 2026, the spec today restricts `exposedTo` to potentially trustworthy origins only, and the `native-agents` token does not exist in the spec.

A related idea is still live: the README's built in agent exposure section discusses a proposed `native-agent` keyword for `exposedTo`. That section is the right home for the open design question. What is stale here is the questionnaire pointing at a merged PR as a pending bikeshed, so this drops the parenthetical to match the current spec.
