### PR TITLE
Document Permissions Policy as a security mitigation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1804,6 +1804,22 @@ respective private browsing modes are safely exposed to [=agents=] and that thes
 
 <h3 id="mitigations">Mitigations</h3>
 
+<h4 id="mitigation-disable-permissions-policy">Disabling WebMCP with Permissions Policy</h4>
+
+**What:** Disable access to WebMCP APIs in documents where WebMCP is not an intended capability.
+
+**Threats addressed:** Unintended tool registration or invocation by scripts executing in those
+documents, including scripts introduced by injection vulnerabilities or compromised dependencies.
+
+**How:** Site authors can deliver a <code>Permissions-Policy: tools=()</code> response header. The
+empty allowlist makes the {{tools}} [=policy-controlled feature=] unavailable to the document and its
+descendants; see [[#permissions-policy]]. This defensive use is not limited to cross-origin
+scenarios: same-origin scripts executing in the document are blocked as well. Because the
+[=user agent=] enforces the policy before WebMCP API operations run, scripts cannot bypass it by
+changing JavaScript load order or replacing page-level guards. This provides defense in depth; it
+does not mitigate the underlying script compromise or prevent scripts from using other web
+capabilities.
+
 <h4 id="mitigation-restrict-input-lengths">Restricting maximum input lengths</h4>
 
 **What:** Restrict the maximum amount of characters

--- a/index.bs
+++ b/index.bs
@@ -1813,12 +1813,9 @@ documents, including scripts introduced by injection vulnerabilities or compromi
 
 **How:** Site authors can deliver a <code>Permissions-Policy: tools=()</code> response header. The
 empty allowlist makes the {{tools}} [=policy-controlled feature=] unavailable to the document and its
-descendants; see [[#permissions-policy]]. This defensive use is not limited to cross-origin
-scenarios: same-origin scripts executing in the document are blocked as well. Because the
-[=user agent=] enforces the policy before WebMCP API operations run, scripts cannot bypass it by
-changing JavaScript load order or replacing page-level guards. This provides defense in depth; it
-does not mitigate the underlying script compromise or prevent scripts from using other web
-capabilities.
+descendants; see [[#permissions-policy]]. This defense applies to every descendant frame, including
+both same-origin and cross-origin ones. The [=user agent=] enforces this before script runs on the
+page, protecting against malicious scripts or dependencies from using WebMCP APIs.
 
 <h4 id="mitigation-restrict-input-lengths">Restricting maximum input lengths</h4>
 


### PR DESCRIPTION
## Summary

- document how site authors can disable WebMCP with Permissions Policy
- explain the same-origin defense-in-depth benefit for injected or compromised scripts
- clarify that the control does not mitigate the underlying script compromise

This follows the deployer guidance proposed by @ck-glen-clarkson in #178.

Closes #178.

## Validation

- W3C spec-generator: Bikeshed processing with die-on=warning
- git diff --check


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mlmrx/webmcp/pull/275.html" title="Last updated on Sep 10, 2026, 10:08 AM UTC (d8f4741)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/275/94c0a3a...mlmrx:d8f4741.html" title="Last updated on Sep 10, 2026, 10:08 AM UTC (d8f4741)">Diff</a>