### PR TITLE
Clarify executeTool input and schema values

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -635,8 +635,28 @@ is a [=model context=] [=struct=] created alongside the {{ModelContext}}.
   <dd>
     <p>Executes a tool on the document it was registered on. Returns a promise that resolves to the
     stringified result of the tool's execution.</p>
+
+    <p><var ignore>tool</var> is a {{RegisteredTool}} returned by {{ModelContext/getTools()}}. Its
+    {{RegisteredTool/inputSchema}} is exposed as a parsed JavaScript object. Callers pass the
+    structured JavaScript value described by that schema as <var ignore>inputObject</var>; the user
+    agent serializes and transfers it to the tool's execution context, so callers do not
+    {{JSON/stringify()}} it first.</p>
   </dd>
 </dl>
+
+<div class=example id=executing-a-discovered-tool>
+  The following discovers a tool and executes it with a JavaScript object:
+
+  ```js
+  const tools = await document.modelContext.getTools();
+  const tool = tools.find(({name}) => name === "example_tool");
+
+  if (tool) {
+    console.log(tool.inputSchema.type); // "object"
+    const result = await document.modelContext.executeTool(tool, {message: "hello"});
+  }
+  ```
+</div>
 
 
 <div algorithm>


### PR DESCRIPTION
## Summary

- clarify that `executeTool()` takes a `RegisteredTool` returned by `getTools()`
- clarify that `RegisteredTool.inputSchema` is exposed as a parsed JavaScript object
- clarify that callers pass the structured JavaScript input value directly rather than pre-serializing it with `JSON.stringify()`
- add a focused discovery-and-execution example to the API introduction

This documents the contract already defined by the `RegisteredTool` dictionary and the
`executeTool()` serialization algorithm. An implementation that exposes `inputSchema` as a string or
requires pre-serialized JSON arguments does not match the current draft.

Closes #278.

## Validation

- W3C spec-generator: Bikeshed processing with `die-on=warning`
- `git diff --check`
