### PR TITLE
Fix the JSON-LD media type in the declarative explainer

### DIFF
--- a/declarative-api-explainer.md
+++ b/declarative-api-explainer.md
@@ -29,7 +29,7 @@ propose:
 3. Two ways of getting a form response back to the agent that invoked the form tool:
     1. `SubmitEvent#respondWith()`, which lets JavaScript on the page override the default form
        action, and pipe a response back to the agent without navigating the page.
-    2. Extracting `<script type="application/json-ld">` tags on the page that the form navigated to,
+    2. Extracting `<script type="application/ld+json">` tags on the page that the form navigated to,
        and using that structured data as a response to the form.
 
 ## Form attributes


### PR DESCRIPTION
One list item in the declarative explainer says `application/json-ld`, which is not a registered media type. The correct type is `application/ld+json`, and this same document already uses the correct form twice in the section on getting the form response to the agent. This fixes the one wrong occurrence.
