### PR TITLE
Fix execution context and navigable lookup algorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1001,31 +1001,31 @@ The <dfn method for=ModelContext>executeTool(<var>tool</var>, <var>inputObject</
    1. Let |completionSteps| be an algorithm that takes a [=string=]-or-null |result| and a
       [=boolean=] |success|, and runs the following steps:
 
-      1. [=Assert=]: these steps are running [=in parallel=].
+      1. Run the following steps [=in parallel=]:
 
-      1. If |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=]'s
-         [=traversable navigable/pending tool executions map=][|uuid|] does not [=map/exist=], then
-         return.
+         1. If |targetDocument|'s [=node navigable=]'s [=navigable/traversable navigable=]'s
+            [=traversable navigable/pending tool executions map=][|uuid|] does not [=map/exist=],
+            then return.
 
-         <div class=note id=pending-execution-removal-race>
-          <p>It is possible that a pending execution identified by |uuid| no longer exists. This can
-          happen due to a race between (a) tool cancellation when the caller document <a
-          href=#caller-destroyed-cleanup>gets destroyed</a> or when the caller aborts the
-          execution via the options signal; and (b) tool promise resolution. Both
-          of these race to invoke |completionSteps|, and the first invocation will remove the
-          pending execution by its key |uuid|, this check protects subsequent racing
-          invocations.</p>
-         </div>
+            <div class=note id=pending-execution-removal-race>
+             <p>It is possible that a pending execution identified by |uuid| no longer exists. This can
+             happen due to a race between (a) tool cancellation when the caller document <a
+             href=#caller-destroyed-cleanup>gets destroyed</a> or when the caller aborts the
+             execution via the options signal; and (b) tool promise resolution. Both
+             of these race to invoke |completionSteps|, and the first invocation will remove the
+             pending execution by its key |uuid|, this check protects subsequent racing
+             invocations.</p>
+            </div>
 
-      1. [=map/Remove=] |targetDocument|'s [=node navigable=]'s [=navigable/traversable
-         navigable=]'s [=traversable navigable/pending tool executions map=][|uuid|].
+         1. [=map/Remove=] |targetDocument|'s [=node navigable=]'s [=navigable/traversable
+            navigable=]'s [=traversable navigable/pending tool executions map=][|uuid|].
 
-      1. If |success| is true, then [=queue a global task=] on the [=webmcp task source=] given
-         |callerDocument|'s [=relevant global object=] to [=resolve=] |promise| with |result|.
+         1. If |success| is true, then [=queue a global task=] on the [=webmcp task source=] given
+            |callerDocument|'s [=relevant global object=] to [=resolve=] |promise| with |result|.
 
-      1. Otherwise, [=queue a global task=] on the [=webmcp task source=] given |callerDocument|'s
-         [=relevant global object=] to [=reject=] |promise| with an "{{UnknownError}}"
-         {{DOMException}}.
+         1. Otherwise, [=queue a global task=] on the [=webmcp task source=] given |callerDocument|'s
+            [=relevant global object=] to [=reject=] |promise| with an "{{UnknownError}}"
+            {{DOMException}}.
 
    1. Let |execution| be a new [=pending tool execution=], with the following [=struct/items=]:
 

--- a/index.bs
+++ b/index.bs
@@ -343,7 +343,7 @@ To <dfn>notify documents of a tool change</dfn> given a {{Document}} |tool owner
 1. [=Assert=]: these steps are running [=in parallel=].
 
 1. Let |navigablesToNotify| be |tool owner|'s [=node navigable=]'s [=navigable/traversable
-   navigable=]'s [=Document/inclusive descendant navigables=].
+   navigable=]'s [=navigable/active document=]'s [=Document/inclusive descendant navigables=].
 
 1. [=list/For each=] |navigable| of |navigablesToNotify|:
 
@@ -478,7 +478,7 @@ internal value=] |uuid|, are as follows:
    Issue: Support more granular errors; here we should return something that prompts the caller to
    reject its {{Promise}} with a "{{DataError}}" {{DOMException}}.
 
-1. If |inputObject| [=Object type|is not an Object=] is false, then run |completionSteps| given null
+1. If |inputObject| [=Object type|is not an Object=], then run |completionSteps| given null
    and false, and abort these steps.
 
    Issue(#146): Specify and fire the "<code>toolactivated</code>" event.
@@ -820,7 +820,7 @@ The <dfn method for=ModelContext>getTools(<var>options</var>)</dfn> method steps
    1. Let |tools| be an empty [=list=] of {{RegisteredTool}} dictionaries.
 
    1. Let |navigables| be |toolRequestor|'s [=node navigable=]'s [=navigable/traversable
-      navigable=]'s [=Document/inclusive descendant navigables=].
+      navigable=]'s [=navigable/active document=]'s [=Document/inclusive descendant navigables=].
 
    1. [=list/For each=] |navigable| of |navigables|:
 


### PR DESCRIPTION
Fix three normative algorithm defects:

- Remove the trailing `is false` from the input type check in imperative execute steps. It currently rejects Object inputs and lets non-Objects proceed.
- Obtain the traversable's active Document before accessing Document-scoped inclusive descendant navigables in tool-change notification and `getTools()`.
- Run the `executeTool()` completion body in parallel before it mutates the traversable's pending-executions map. Its former assertion required that context, while most callers run from a Document event loop.

The navigation change completes the receiver correction left after #244 changed the notification traversal to be inclusive. `perform an observation` already uses the active Document.

Fixes #305.

Validation: `bikeshed --print=plain --dry-run --die-on=warning spec index.bs` passed without warnings after all three corrections. The diff changes only `index.bs`; Bikeshed validates markup and references, while the algorithm changes were checked against the stated execution-context and traversal invariants.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/emecii/webmcp/pull/301.html" title="Last updated on Sep 7, 2026, 4:00 PM UTC (e6e6376)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/301/50c4b7f...emecii:e6e6376.html" title="Last updated on Sep 7, 2026, 4:00 PM UTC (e6e6376)">Diff</a>