### PR TITLE
Fix malformed tool registration and lookup steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -669,7 +669,7 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 1. If |tool map|[|tool name|] [=map/exists=], then return [=a promise rejected with=] an
    {{InvalidStateError}} {{DOMException}}.
 
-1. If |tool name| or {{ModelContextTool/description}} is an empty string, then return [=a promise
+1. If |tool|'s {{ModelContextTool/description}} is the empty string, then return [=a promise
    rejected with=] an {{InvalidStateError}} {{DOMException}}.
 
 1. If either |tool name| is the empty string, or its [=string/length=] is greater than 128, or if
@@ -721,9 +721,6 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 1. If |options|'s {{ModelContextRegisterToolOptions/signal}} [=map/exists=], then:
 
    1. Let |signal| be |options|'s {{ModelContextRegisterToolOptions/signal}}.
-
-   1. If |signal| is [=AbortSignal/aborted=], then return [=a promise rejected with=]
-      |signal|'s [=AbortSignal/abort reason=].
 
    1. [=AbortSignal/add|Add the following abort steps=] to |signal|:
 
@@ -833,8 +830,8 @@ The <dfn method for=ModelContext>getTools(<var>options</var>)</dfn> method steps
 
       1. Let |callerOrigin| be |toolRequestor|'s [=Document/origin=].
 
-      1. If |toolOwnerIsRequested| be true if |targetOrigin| is [=same origin=] with |callerOrigin|,
-         or if |from origins| [=list/contains=] |targetOrigin|; otherwise, false.
+      1. Let |toolOwnerIsRequested| be true if |targetOrigin| is [=same origin=] with
+         |callerOrigin|, or if |from origins| [=list/contains=] |targetOrigin|; otherwise, false.
 
       1. If |toolOwnerIsRequested| is false, then [=iteration/continue=].
 

--- a/index.bs
+++ b/index.bs
@@ -669,13 +669,12 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 1. If |tool map|[|tool name|] [=map/exists=], then return [=a promise rejected with=] an
    {{InvalidStateError}} {{DOMException}}.
 
-1. If |tool|'s {{ModelContextTool/description}} is the empty string, then return [=a promise
-   rejected with=] an {{InvalidStateError}} {{DOMException}}.
+1. If |tool name| is not a non-empty string or |tool|'s {{ModelContextTool/description}} is the
+   empty string, then return [=a promise rejected with=] an {{InvalidStateError}} {{DOMException}}.
 
-1. If either |tool name| is the empty string, or its [=string/length=] is greater than 128, or if
-   |tool name| contains a [=code point=] that is not an [=ASCII alphanumeric=], U+005F (_),
-   U+002D (-), or U+002E (.), then return [=a promise rejected with=] an {{InvalidStateError}}
-   {{DOMException}}.
+1. If |tool name|'s [=string/length=] is greater than 128, or if |tool name| contains a [=code
+   point=] that is not an [=ASCII alphanumeric=], U+005F (_), U+002D (-), or U+002E (.), then
+   return [=a promise rejected with=] an {{InvalidStateError}} {{DOMException}}.
 
 1. Let |stringified input schema| be the empty string.
 
@@ -721,6 +720,9 @@ The <dfn method for=ModelContext>registerTool(<var>tool</var>, <var>options</var
 1. If |options|'s {{ModelContextRegisterToolOptions/signal}} [=map/exists=], then:
 
    1. Let |signal| be |options|'s {{ModelContextRegisterToolOptions/signal}}.
+
+   1. If |signal| is [=AbortSignal/aborted=], then return [=a promise rejected with=]
+      |signal|'s [=AbortSignal/abort reason=].
 
    1. [=AbortSignal/add|Add the following abort steps=] to |signal|:
 


### PR DESCRIPTION
Clarify `registerTool()` validation by checking the tool name (empty string, length, and allowed code points) before the description, matching Chromium. Qualify the description member access with `|tool|`. The existing aborted-signal checks remain intact so the promise rejection behavior is preserved.

Also replace the malformed `If ... be true if` step with `Let ... be true if` in `getTools()`.

Validation: `bikeshed --print=plain --dry-run --die-on=warning spec index.bs` and `make lint` pass without warnings. Branch is independent of the input/navigation fix and based on `50c4b7f`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/emecii/webmcp/pull/302.html" title="Last updated on Sep 14, 2026, 7:25 AM UTC (8687256)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webmcp/302/50c4b7f...emecii:8687256.html" title="Last updated on Sep 14, 2026, 7:25 AM UTC (8687256)">Diff</a>